### PR TITLE
Fixes #204: NullPointerException when validating representation without descriptive metadata and no dmdSec in METS

### DIFF
--- a/src/main/java/org/roda_project/commons_ip2/validator/common/FolderManager.java
+++ b/src/main/java/org/roda_project/commons_ip2/validator/common/FolderManager.java
@@ -107,12 +107,12 @@ public class FolderManager {
   public int countMetadataFiles(final Path path) {
     int count = 0;
     final File[] folder = path.toFile().listFiles();
-    if (path.toString().contains("descriptive")) {
-      for (File ignored : folder) {
-        count++;
-      }
-    } else {
-      if (folder != null) {
+    if (folder != null) {
+      if (path.toString().contains("descriptive")) {
+        for (File ignored : folder) {
+          count++;
+        }
+      } else {
         for (File f : folder) {
           if (f.getName().equals("metadata")) {
             if (f.isDirectory()) {


### PR DESCRIPTION
Moving the `if (folder != null)` condition to ensure that counting descriptive metadata files does not throw a NullPointerException when no descriptive files exists. Fixes #204 