### PR TITLE
Fix: Handle NullPointerException when instantiating EARKSIP without a version

### DIFF
--- a/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKSIP.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKSIP.java
@@ -68,7 +68,7 @@ public class EARKSIP extends SIP {
    *          will be used as OBJID in METS (/mets[@OBJID])
    */
   public EARKSIP(String sipId, IPContentType contentType, IPContentInformationType contentInformationType) {
-    new EARKSIP(sipId, contentType, contentInformationType, DEFAULT_SIP_VERSION);
+    this(sipId, contentType, contentInformationType, DEFAULT_SIP_VERSION);
   }
 
   public EARKSIP(String sipId, IPContentType contentType, IPContentInformationType contentInformationType, String version) {


### PR DESCRIPTION


Closes #254.