### PR TITLE
Potential fix for code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/org/roda_project/commons_ip2/utils/ZIPUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/utils/ZIPUtils.java
@@ -225,7 +225,11 @@ public final class ZIPUtils {
         if (Utils.systemIsWindows()) {
           entryName = entryName.replaceAll("/", "\\\\");
         }
-        Path newFile = dest.resolve(entryName);
+        Path newFile = dest.resolve(entryName).normalize();
+
+        if (!newFile.startsWith(dest.normalize())) {
+          throw new IOException("Bad zip entry: " + entryName);
+        }
 
         if (zipEntry.isDirectory()) {
           Files.createDirectories(newFile);


### PR DESCRIPTION
Potential fix for [https://github.com/keeps/commons-ip/security/code-scanning/2](https://github.com/keeps/commons-ip/security/code-scanning/2)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This can be achieved by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory. We will use `java.nio.file.Path.normalize()` and `java.nio.file.Path.startsWith(..)` for this purpose.

1. Normalize the `newFile` path.
2. Check if the normalized `newFile` path starts with the normalized `dest` path.
3. If the check fails, throw an exception to prevent writing the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
