### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/org/roda_project/commons_ip/utils/ZIPUtils.java
+++ b/src/main/java/org/roda_project/commons_ip/utils/ZIPUtils.java
@@ -225,6 +225,10 @@ public final class ZIPUtils {
         }
         Path newFile = dest.resolve(entryName).normalize();
 
+        if (!newFile.startsWith(dest.normalize())) {
+          throw new IOException("Bad zip entry: " + entryName);
+        }
+
         if (zipEntry.isDirectory()) {
           Files.createDirectories(newFile);
         } else {


### PR DESCRIPTION
Potential fix for [https://github.com/keeps/commons-ip/security/code-scanning/1](https://github.com/keeps/commons-ip/security/code-scanning/1)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This can be achieved by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory. If the check fails, an exception should be thrown.

1. Modify the code to check if the normalized path of the new file starts with the destination directory.
2. If the check fails, throw an exception to prevent the extraction of the file.
3. Ensure that the check is performed before any file system operations are executed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
