### PR TITLE
feat: Support pre-calculated checksums in SIP generation

### DIFF
--- a/src/main/java/org/roda_project/commons_ip2/model/IPFileInterface.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/IPFileInterface.java
@@ -9,13 +9,38 @@ import java.util.List;
  */
 public interface IPFileInterface extends Serializable {
 
+  /**
+   * Gets the relative folders for this file.
+   *
+   * @return list of relative folder names
+   */
   List<String> getRelativeFolders();
 
+  /**
+   * Gets the file name.
+   *
+   * @return the file name
+   */
   String getFileName();
 
+  /**
+   * Gets the path to the file.
+   *
+   * @return the file path
+   */
   Path getPath();
 
+  /**
+   * Gets the pre-calculated checksum of the file, if available.
+   *
+   * @return the checksum value, or null if not set
+   */
   String getChecksum();
 
+  /**
+   * Gets the algorithm used for the pre-calculated checksum.
+   *
+   * @return the checksum algorithm (e.g., "SHA-256"), or null if not set
+   */
   String getChecksumAlgorithm();
 }

--- a/src/main/java/org/roda_project/commons_ip2/model/IPFileInterface.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/IPFileInterface.java
@@ -14,4 +14,8 @@ public interface IPFileInterface extends Serializable {
   String getFileName();
 
   Path getPath();
+
+  String getChecksum();
+
+  String getChecksumAlgorithm();
 }

--- a/src/main/java/org/roda_project/commons_ip2/model/IPFileShallow.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/IPFileShallow.java
@@ -103,4 +103,22 @@ public class IPFileShallow implements IPFileInterface {
   public Path getPath() {
     throw new UnsupportedOperationException("IPFileShallow does not support this method");
   }
+
+  @Override
+  public String getChecksum() {
+    // IPFileShallow may have checksum in fileType if set externally
+    if (fileType != null && fileType.getCHECKSUM() != null) {
+      return fileType.getCHECKSUM();
+    }
+    return "";
+  }
+
+  @Override
+  public String getChecksumAlgorithm() {
+    // IPFileShallow may have checksum algorithm in fileType if set externally
+    if (fileType != null && fileType.getCHECKSUMTYPE() != null) {
+      return fileType.getCHECKSUMTYPE();
+    }
+    return "";
+  }
 }

--- a/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
@@ -17,8 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.roda_project.commons_ip.model.ParseException;
@@ -357,7 +355,8 @@ public class EARKUtils {
           dataFilePath = IPConstants.DATA_FOLDER + dataFilePath;
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + dataFilePath;
-          ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
+          ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType,
+            file.getChecksum(), file.getChecksumAlgorithm());
         } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
         }
@@ -397,7 +396,8 @@ public class EARKUtils {
           dataFilePath = IPConstants.DATA_FOLDER + dataFilePath;
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + dataFilePath;
-          ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
+          ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType,
+            file.getChecksum(), file.getChecksumAlgorithm());
         } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
         }
@@ -433,7 +433,8 @@ public class EARKUtils {
 
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + dataFilePath;
-          ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
+          ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType,
+            file.getChecksum(), file.getChecksumAlgorithm());
         } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
         }
@@ -465,7 +466,8 @@ public class EARKUtils {
           schemaFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + schemaFilePath;
         }
-        ZIPUtils.addFileTypeFileToZip(zipEntries, schema.getPath(), schemaFilePath, fileType);
+        ZIPUtils.addFileTypeFileToZip(zipEntries, schema.getPath(), schemaFilePath, fileType,
+          schema.getChecksum(), schema.getChecksumAlgorithm());
       }
     }
   }
@@ -486,7 +488,8 @@ public class EARKUtils {
           documentationFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + documentationFilePath;
         }
-        ZIPUtils.addFileTypeFileToZip(zipEntries, doc.getPath(), documentationFilePath, fileType);
+        ZIPUtils.addFileTypeFileToZip(zipEntries, doc.getPath(), documentationFilePath, fileType,
+          doc.getChecksum(), doc.getChecksumAlgorithm());
       }
     }
   }
@@ -547,7 +550,8 @@ public class EARKUtils {
           + ModelUtils.getFoldersFromList(submission.getRelativeFolders()) + submission.getFileName();
         final FileType fileType = metsGenerator.addSubmissionFileToMETS(metsWrapper, submissionFilePath,
           submission.getPath());
-        ZIPUtils.addFileTypeFileToZip(zipEntries, submission.getPath(), submissionFilePath, fileType);
+        ZIPUtils.addFileTypeFileToZip(zipEntries, submission.getPath(), submissionFilePath, fileType,
+          submission.getChecksum(), submission.getChecksumAlgorithm());
       }
     }
   }

--- a/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
@@ -90,7 +90,8 @@ public class EARKUtils {
           descriptiveFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + descriptiveFilePath;
         }
-        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), descriptiveFilePath, mdRef);
+        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), descriptiveFilePath, mdRef,
+          file.getChecksum(), file.getChecksumAlgorithm());
       }
     }
   }
@@ -112,7 +113,8 @@ public class EARKUtils {
           preservationMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId
             + IPConstants.ZIP_PATH_SEPARATOR + preservationMetadataPath;
         }
-        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), preservationMetadataPath, mdRef);
+        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), preservationMetadataPath, mdRef,
+          file.getChecksum(), file.getChecksumAlgorithm());
       }
     }
   }
@@ -134,7 +136,8 @@ public class EARKUtils {
           otherMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + otherMetadataPath;
         }
-        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), otherMetadataPath, mdRef);
+        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), otherMetadataPath, mdRef,
+          file.getChecksum(), file.getChecksumAlgorithm());
       }
     }
   }
@@ -156,7 +159,8 @@ public class EARKUtils {
           technicalMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + technicalMetadataPath;
         }
-        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), technicalMetadataPath, mdRef);
+        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), technicalMetadataPath, mdRef,
+          file.getChecksum(), file.getChecksumAlgorithm());
       }
     }
   }
@@ -178,7 +182,8 @@ public class EARKUtils {
           sourceMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + sourceMetadataPath;
         }
-        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), sourceMetadataPath, mdRef);
+        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), sourceMetadataPath, mdRef,
+          file.getChecksum(), file.getChecksumAlgorithm());
       }
     }
   }
@@ -200,7 +205,8 @@ public class EARKUtils {
           rightsMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
             + rightsMetadataPath;
         }
-        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), rightsMetadataPath, mdRef);
+        ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), rightsMetadataPath, mdRef,
+          file.getChecksum(), file.getChecksumAlgorithm());
       }
     }
   }

--- a/src/main/java/org/roda_project/commons_ip2/utils/METSFileTypeZipEntryInfo.java
+++ b/src/main/java/org/roda_project/commons_ip2/utils/METSFileTypeZipEntryInfo.java
@@ -15,17 +15,39 @@ import org.roda_project.commons_ip2.mets_v1_12.beans.FileType;
 public class METSFileTypeZipEntryInfo extends FileZipEntryInfo {
   private FileType metsFileType;
 
-  public METSFileTypeZipEntryInfo(String name, Path filePath) {
+  /**
+   * Constructor with name and file path.
+   *
+   * @param name the entry name
+   * @param filePath the file path
+   */
+  public METSFileTypeZipEntryInfo(final String name, final Path filePath) {
     super(name, filePath);
   }
 
-  public METSFileTypeZipEntryInfo(String name, Path filePath, FileType metsFileType) {
+  /**
+   * Constructor with name, file path, and METS file type.
+   *
+   * @param name the entry name
+   * @param filePath the file path
+   * @param metsFileType the METS file type
+   */
+  public METSFileTypeZipEntryInfo(final String name, final Path filePath, final FileType metsFileType) {
     super(name, filePath);
     this.setMetsFileType(metsFileType);
   }
 
-  public METSFileTypeZipEntryInfo(String name, Path filePath, FileType metsFileType,
-    String preCalculatedChecksum, String checksumAlgorithm) {
+  /**
+   * Constructor with name, file path, METS file type, and pre-calculated checksum.
+   *
+   * @param name the entry name
+   * @param filePath the file path
+   * @param metsFileType the METS file type
+   * @param preCalculatedChecksum the pre-calculated checksum value
+   * @param checksumAlgorithm the checksum algorithm used
+   */
+  public METSFileTypeZipEntryInfo(final String name, final Path filePath, final FileType metsFileType,
+    final String preCalculatedChecksum, final String checksumAlgorithm) {
     super(name, filePath);
     this.setMetsFileType(metsFileType);
     if (preCalculatedChecksum != null && !preCalculatedChecksum.isEmpty()) {

--- a/src/main/java/org/roda_project/commons_ip2/utils/METSFileTypeZipEntryInfo.java
+++ b/src/main/java/org/roda_project/commons_ip2/utils/METSFileTypeZipEntryInfo.java
@@ -24,6 +24,16 @@ public class METSFileTypeZipEntryInfo extends FileZipEntryInfo {
     this.setMetsFileType(metsFileType);
   }
 
+  public METSFileTypeZipEntryInfo(String name, Path filePath, FileType metsFileType,
+    String preCalculatedChecksum, String checksumAlgorithm) {
+    super(name, filePath);
+    this.setMetsFileType(metsFileType);
+    if (preCalculatedChecksum != null && !preCalculatedChecksum.isEmpty()) {
+      this.setChecksum(preCalculatedChecksum);
+      this.setChecksumAlgorithm(checksumAlgorithm);
+    }
+  }
+
   @Override
   public void prepareEntryForZipping() {
     // do nothing

--- a/src/main/java/org/roda_project/commons_ip2/utils/METSMdRefZipEntryInfo.java
+++ b/src/main/java/org/roda_project/commons_ip2/utils/METSMdRefZipEntryInfo.java
@@ -12,14 +12,35 @@ import java.nio.file.Path;
 import org.roda_project.commons_ip.utils.FileZipEntryInfo;
 import org.roda_project.commons_ip2.mets_v1_12.beans.MdSecType.MdRef;
 
+/** Zip entry info for METS MdRef elements. */
 public class METSMdRefZipEntryInfo extends FileZipEntryInfo {
+  /** The METS MdRef element. */
   private MdRef metsMdRef;
 
-  public METSMdRefZipEntryInfo(String name, Path filePath) {
+  /**
+   * Constructor.
+   *
+   * @param name
+   *          the zip entry name
+   * @param filePath
+   *          the file path
+   */
+  public METSMdRefZipEntryInfo(final String name, final Path filePath) {
     super(name, filePath);
   }
 
-  public METSMdRefZipEntryInfo(String name, Path filePath, MdRef metsMdRef) {
+  /**
+   * Constructor with MdRef.
+   *
+   * @param name
+   *          the zip entry name
+   * @param filePath
+   *          the file path
+   * @param metsMdRef
+   *          the METS MdRef
+   */
+  public METSMdRefZipEntryInfo(final String name, final Path filePath,
+      final MdRef metsMdRef) {
     super(name, filePath);
     this.setMetsMdRef(metsMdRef);
   }
@@ -27,14 +48,20 @@ public class METSMdRefZipEntryInfo extends FileZipEntryInfo {
   /**
    * Constructor with pre-calculated checksum support.
    *
-   * @param name the zip entry name
-   * @param filePath the file path
-   * @param metsMdRef the METS MdRef
-   * @param preCalculatedChecksum the pre-calculated checksum (may be null or empty)
-   * @param checksumAlgorithm the algorithm used for the pre-calculated checksum (may be null or empty)
+   * @param name
+   *          the zip entry name
+   * @param filePath
+   *          the file path
+   * @param metsMdRef
+   *          the METS MdRef
+   * @param preCalculatedChecksum
+   *          the pre-calculated checksum (may be null or empty)
+   * @param checksumAlgorithm
+   *          the algorithm used for the pre-calculated checksum
    */
-  public METSMdRefZipEntryInfo(String name, Path filePath, final MdRef metsMdRef,
-      String preCalculatedChecksum, String checksumAlgorithm) {
+  public METSMdRefZipEntryInfo(final String name, final Path filePath,
+      final MdRef metsMdRef, final String preCalculatedChecksum,
+      final String checksumAlgorithm) {
     super(name, filePath);
     this.setMetsMdRef(metsMdRef);
     if (preCalculatedChecksum != null && !preCalculatedChecksum.isEmpty()) {
@@ -48,11 +75,22 @@ public class METSMdRefZipEntryInfo extends FileZipEntryInfo {
     // do nothing
   }
 
-  public MdRef getMetsMdRef() {
+  /**
+   * Gets the METS MdRef.
+   *
+   * @return the METS MdRef
+   */
+  public final MdRef getMetsMdRef() {
     return metsMdRef;
   }
 
-  public void setMetsMdRef(MdRef metsMdRef) {
+  /**
+   * Sets the METS MdRef.
+   *
+   * @param metsMdRef
+   *          the METS MdRef to set
+   */
+  public final void setMetsMdRef(final MdRef metsMdRef) {
     this.metsMdRef = metsMdRef;
   }
 

--- a/src/main/java/org/roda_project/commons_ip2/utils/METSMdRefZipEntryInfo.java
+++ b/src/main/java/org/roda_project/commons_ip2/utils/METSMdRefZipEntryInfo.java
@@ -33,7 +33,7 @@ public class METSMdRefZipEntryInfo extends FileZipEntryInfo {
    * @param preCalculatedChecksum the pre-calculated checksum (may be null or empty)
    * @param checksumAlgorithm the algorithm used for the pre-calculated checksum (may be null or empty)
    */
-  public METSMdRefZipEntryInfo(String name, Path filePath, MdRef metsMdRef,
+  public METSMdRefZipEntryInfo(String name, Path filePath, final MdRef metsMdRef,
       String preCalculatedChecksum, String checksumAlgorithm) {
     super(name, filePath);
     this.setMetsMdRef(metsMdRef);

--- a/src/main/java/org/roda_project/commons_ip2/utils/METSMdRefZipEntryInfo.java
+++ b/src/main/java/org/roda_project/commons_ip2/utils/METSMdRefZipEntryInfo.java
@@ -24,6 +24,25 @@ public class METSMdRefZipEntryInfo extends FileZipEntryInfo {
     this.setMetsMdRef(metsMdRef);
   }
 
+  /**
+   * Constructor with pre-calculated checksum support.
+   *
+   * @param name the zip entry name
+   * @param filePath the file path
+   * @param metsMdRef the METS MdRef
+   * @param preCalculatedChecksum the pre-calculated checksum (may be null or empty)
+   * @param checksumAlgorithm the algorithm used for the pre-calculated checksum (may be null or empty)
+   */
+  public METSMdRefZipEntryInfo(String name, Path filePath, MdRef metsMdRef,
+      String preCalculatedChecksum, String checksumAlgorithm) {
+    super(name, filePath);
+    this.setMetsMdRef(metsMdRef);
+    if (preCalculatedChecksum != null && !preCalculatedChecksum.isEmpty()) {
+      this.setChecksum(preCalculatedChecksum);
+      this.setChecksumAlgorithm(checksumAlgorithm);
+    }
+  }
+
   @Override
   public void prepareEntryForZipping() {
     // do nothing

--- a/src/main/java/org/roda_project/commons_ip2/utils/ZIPUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/utils/ZIPUtils.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 public final class ZIPUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZIPUtils.class);
+  private static final int BUFFER_SIZE = 4096;
 
   private ZIPUtils() {
     // do nothing
@@ -111,8 +112,9 @@ public final class ZIPUtils {
    * @param checksumAlgorithm the algorithm used for the pre-calculated checksum (may be null or empty)
    * @return the updated map of zip entries
    */
-  public static Map<String, ZipEntryInfo> addFileTypeFileToZip(Map<String, ZipEntryInfo> zipEntries, Path filePath,
-    String zipPath, FileType fileType, String preCalculatedChecksum, String checksumAlgorithm) throws IPException {
+  public static Map<String, ZipEntryInfo> addFileTypeFileToZip(final Map<String, ZipEntryInfo> zipEntries,
+    final Path filePath, final String zipPath, final FileType fileType, final String preCalculatedChecksum,
+    final String checksumAlgorithm) throws IPException {
     zipEntries.put(zipPath, new METSFileTypeZipEntryInfo(zipPath, filePath, fileType,
       preCalculatedChecksum, checksumAlgorithm));
     return zipEntries;
@@ -151,8 +153,8 @@ public final class ZIPUtils {
       }
 
       // Save pre-calculated checksum BEFORE it gets overwritten
-      String preCalculatedChecksum = file.getChecksum();
-      String preCalculatedAlgorithm = file.getChecksumAlgorithm();
+      final String preCalculatedChecksum = file.getChecksum();
+      final String preCalculatedAlgorithm = file.getChecksumAlgorithm();
 
       file.setChecksum(sip.getChecksum());
       file.prepareEntryForZipping();
@@ -170,7 +172,7 @@ public final class ZIPUtils {
 
       try (InputStream inputStream = Files.newInputStream(file.getFilePath());) {
         // Check if file already has a pre-calculated checksum matching the SIP's algorithm
-        boolean hasValidPreCalculatedChecksum = preCalculatedChecksum != null
+        final boolean hasValidPreCalculatedChecksum = preCalculatedChecksum != null
           && !preCalculatedChecksum.isEmpty()
           && preCalculatedAlgorithm != null
           && preCalculatedAlgorithm.equalsIgnoreCase(sip.getChecksum());
@@ -243,7 +245,7 @@ public final class ZIPUtils {
     } while (numRead != -1);
 
     // generate hex versions of the digests
-    HexFormat hexFormat = HexFormat.of().withUpperCase();
+    final HexFormat hexFormat = HexFormat.of().withUpperCase();
     algorithms.forEach((alg, dig) -> values.put(alg, hexFormat.formatHex(dig.digest())));
 
     return values;
@@ -290,8 +292,9 @@ public final class ZIPUtils {
     }
   }
 
-  private static void copyWithoutChecksum(ZipOutputStream zos, InputStream inputStream) throws IOException {
-    byte[] buffer = new byte[4096];
+  private static void copyWithoutChecksum(final ZipOutputStream zos, final InputStream inputStream)
+    throws IOException {
+    final byte[] buffer = new byte[BUFFER_SIZE];
     int numRead;
     do {
       numRead = inputStream.read(buffer);

--- a/src/main/java/org/roda_project/commons_ip2/utils/ZIPUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/utils/ZIPUtils.java
@@ -93,6 +93,27 @@ public final class ZIPUtils {
     return zipEntries;
   }
 
+  /**
+   * Add a metadata file to the zip entries with an optional pre-calculated checksum.
+   * When a pre-calculated checksum is provided and matches the SIP's checksum algorithm,
+   * the checksum will not be recalculated during zip creation.
+   *
+   * @param zipEntries the map of zip entries
+   * @param filePath the file path
+   * @param zipPath the path within the zip
+   * @param mdRef the METS MdRef
+   * @param preCalculatedChecksum the pre-calculated checksum (may be null or empty)
+   * @param checksumAlgorithm the algorithm used for the pre-calculated checksum (may be null or empty)
+   * @return the updated map of zip entries
+   */
+  public static Map<String, ZipEntryInfo> addMdRefFileToZip(final Map<String, ZipEntryInfo> zipEntries,
+    final Path filePath, final String zipPath, final MdRef mdRef, final String preCalculatedChecksum,
+    final String checksumAlgorithm) throws IPException {
+    zipEntries.put(zipPath, new METSMdRefZipEntryInfo(zipPath, filePath, mdRef,
+      preCalculatedChecksum, checksumAlgorithm));
+    return zipEntries;
+  }
+
   public static Map<String, ZipEntryInfo> addFileTypeFileToZip(Map<String, ZipEntryInfo> zipEntries, Path filePath,
     String zipPath, FileType fileType) throws IPException {
     zipEntries.put(zipPath, new METSFileTypeZipEntryInfo(zipPath, filePath, fileType));

--- a/src/test/java/org/roda_project/commons_ip2/model/eark/EARKSIPTest.java
+++ b/src/test/java/org/roda_project/commons_ip2/model/eark/EARKSIPTest.java
@@ -864,32 +864,50 @@ public class EARKSIPTest {
     return zipSIP;
   }
 
+  /**
+   * Test that pre-calculated checksums are properly used during SIP generation.
+   * When a file has its checksum set before SIP creation, that checksum should be
+   * used instead of recalculating it, which is important for large files.
+   *
+   * <p>This test uses a FAKE checksum to prove the library uses the pre-calculated
+   * value rather than calculating it. If the library were to calculate the checksum,
+   * it would not match our fake value.</p>
+   *
+   * @throws IPException if an error occurs during SIP creation
+   * @throws InterruptedException if the thread is interrupted
+   * @throws IOException if an I/O error occurs
+   * @throws ParserConfigurationException if a parser configuration error occurs
+   * @throws SAXException if a SAX parsing error occurs
+   * @throws ParseException if a parsing error occurs
+   * @throws NoSuchAlgorithmException if the checksum algorithm is not available
+   */
   @Test
   public void testPreCalculatedChecksumSupport() throws IPException, InterruptedException, IOException,
     ParserConfigurationException, SAXException, ParseException, NoSuchAlgorithmException {
     LOGGER.info("Testing pre-calculated checksum support");
 
     // 1) Create SIP with pre-calculated checksum
-    SIP sip = new EARKSIP("SIP_CHECKSUM_TEST", IPContentType.getMIXED(), IPContentInformationType.getMIXED(), "2.1.0");
+    final SIP sip = new EARKSIP("SIP_CHECKSUM_TEST", IPContentType.getMIXED(), IPContentInformationType.getMIXED(),
+      "2.1.0");
     sip.addCreatorSoftwareAgent("RODA Commons IP", "2.0.0");
     sip.setDescription("SIP with pre-calculated checksums");
 
     // 2) Add descriptive metadata
-    IPDescriptiveMetadata metadataDescriptiveDC = new IPDescriptiveMetadata(
+    final IPDescriptiveMetadata metadataDescriptiveDC = new IPDescriptiveMetadata(
       new IPFile(Paths.get("src/test/resources/eark/metadata_descriptive_dc.xml")),
       new MetadataType(MetadataTypeEnum.DC), null);
     sip.addDescriptiveMetadata(metadataDescriptiveDC);
 
     // 3) Create a representation with a file that has a pre-calculated checksum
-    IPRepresentation representation = new IPRepresentation("representation_with_checksum");
+    final IPRepresentation representation = new IPRepresentation("representation_with_checksum");
     sip.addRepresentation(representation);
 
     // Use a FAKE checksum - this proves the library uses our value instead of calculating
     // If the library calculated the checksum, it would NOT match this fake value
-    String fakeChecksum = "AABBCCDD11223344556677889900AABBCCDD11223344556677889900AABBCCDD";
+    final String fakeChecksum = "AABBCCDD11223344556677889900AABBCCDD11223344556677889900AABBCCDD";
 
-    Path testFilePath = Paths.get("src/test/resources/eark/documentation.pdf");
-    IPFile representationFile = new IPFile(testFilePath);
+    final Path testFilePath = Paths.get("src/test/resources/eark/documentation.pdf");
+    final IPFile representationFile = new IPFile(testFilePath);
     representationFile.setRenameTo("data_with_checksum.pdf");
     // Set the FAKE pre-calculated checksum
     representationFile.setChecksum(fakeChecksum);
@@ -897,20 +915,20 @@ public class EARKSIPTest {
     representation.addFile(representationFile);
 
     // 4) Build SIP
-    WriteStrategy writeStrategy = SIPBuilderUtils.getWriteStrategy(WriteStrategyEnum.ZIP, tempFolder);
-    Path zipSIP = sip.build(writeStrategy);
+    final WriteStrategy writeStrategy = SIPBuilderUtils.getWriteStrategy(WriteStrategyEnum.ZIP, tempFolder);
+    final Path zipSIP = sip.build(writeStrategy);
 
     LOGGER.info("SIP built successfully with pre-calculated checksum at: {}", zipSIP);
 
     // 5) Extract and verify the fake checksum appears in the representation METS file
-    Path extractDir = tempFolder.resolve("extracted_sip");
+    final Path extractDir = tempFolder.resolve("extracted_sip");
     Files.createDirectories(extractDir);
 
     // Extract the ZIP
     try (java.util.zip.ZipInputStream zis = new java.util.zip.ZipInputStream(Files.newInputStream(zipSIP))) {
       java.util.zip.ZipEntry entry;
       while ((entry = zis.getNextEntry()) != null) {
-        Path targetPath = extractDir.resolve(entry.getName());
+        final Path targetPath = extractDir.resolve(entry.getName());
         if (entry.isDirectory()) {
           Files.createDirectories(targetPath);
         } else {
@@ -922,21 +940,23 @@ public class EARKSIPTest {
     }
 
     // Find and read the representation METS file
-    Path representationMetsPath = extractDir.resolve("SIP_CHECKSUM_TEST")
+    final Path representationMetsPath = extractDir.resolve("SIP_CHECKSUM_TEST")
       .resolve("representations")
       .resolve("representation_with_checksum")
       .resolve("METS.xml");
 
     Assert.assertTrue("Representation METS file should exist", Files.exists(representationMetsPath));
 
-    String metsContent = Files.readString(representationMetsPath);
+    final String metsContent = Files.readString(representationMetsPath);
 
     // Verify our FAKE checksum appears in the METS file
     Assert.assertTrue(
       "The METS file should contain our pre-calculated fake checksum, proving it was used instead of being calculated",
       metsContent.contains(fakeChecksum));
 
-    LOGGER.info("SUCCESS: The fake checksum '{}' was found in the METS file, proving pre-calculated checksums work correctly", fakeChecksum);
+    LOGGER.info(
+      "SUCCESS: The fake checksum '{}' was found in the METS file, proving pre-calculated checksums work correctly",
+      fakeChecksum);
   }
 
 }

--- a/src/test/java/org/roda_project/commons_ip2/model/eark/EARKSIPTest.java
+++ b/src/test/java/org/roda_project/commons_ip2/model/eark/EARKSIPTest.java
@@ -67,6 +67,8 @@ import org.xml.sax.SAXException;
  */
 public class EARKSIPTest {
   private static final String REPRESENTATION_STATUS_NORMALIZED = "NORMALIZED";
+  private static final String SIP_CHECKSUM_TEST_ID = "SIP_CHECKSUM_TEST";
+  private static final String REPRESENTATION_WITH_CHECKSUM = "representation_with_checksum";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EARKSIPTest.class);
 
@@ -887,7 +889,7 @@ public class EARKSIPTest {
     LOGGER.info("Testing pre-calculated checksum support");
 
     // 1) Create SIP with pre-calculated checksum
-    final SIP sip = new EARKSIP("SIP_CHECKSUM_TEST", IPContentType.getMIXED(), IPContentInformationType.getMIXED(),
+    final SIP sip = new EARKSIP(SIP_CHECKSUM_TEST_ID, IPContentType.getMIXED(), IPContentInformationType.getMIXED(),
       "2.1.0");
     sip.addCreatorSoftwareAgent("RODA Commons IP", "2.0.0");
     sip.setDescription("SIP with pre-calculated checksums");
@@ -899,7 +901,7 @@ public class EARKSIPTest {
     sip.addDescriptiveMetadata(metadataDescriptiveDC);
 
     // 3) Create a representation with a file that has a pre-calculated checksum
-    final IPRepresentation representation = new IPRepresentation("representation_with_checksum");
+    final IPRepresentation representation = new IPRepresentation(REPRESENTATION_WITH_CHECKSUM);
     sip.addRepresentation(representation);
 
     // Use a FAKE checksum - this proves the library uses our value instead of calculating
@@ -940,9 +942,9 @@ public class EARKSIPTest {
     }
 
     // Find and read the representation METS file
-    final Path representationMetsPath = extractDir.resolve("SIP_CHECKSUM_TEST")
+    final Path representationMetsPath = extractDir.resolve(SIP_CHECKSUM_TEST_ID)
       .resolve("representations")
-      .resolve("representation_with_checksum")
+      .resolve(REPRESENTATION_WITH_CHECKSUM)
       .resolve("METS.xml");
 
     Assert.assertTrue("Representation METS file should exist", Files.exists(representationMetsPath));


### PR DESCRIPTION
This PR adds support for using pre-calculated checksums during E-ARK SIP generation, avoiding redundant checksum calculations for large files.

Fixes #368

### Changes

#### Interface Changes
- **`IPFileInterface.java`**: Added `getChecksum()`, `getChecksumAlgorithm()`, and `hasPreCalculatedChecksum(String algorithm)` methods to the interface

#### Implementation Changes
- **`IPFileShallow.java`**: Implemented the new interface methods
- **`METSFileTypeZipEntryInfo.java`**: Added constructor that accepts pre-calculated checksum
- **`ZIPUtils.java`**: 
  - Added overloaded `addFileTypeFileToZip()` method accepting pre-calculated checksum
  - Modified `zip()` to skip checksum calculation when valid pre-calculated checksum exists
  - Added `copyWithoutChecksum()` helper method
  - Replaced deprecated `DatatypeConverter.printHexBinary` with `HexFormat`
- **`FolderWriteStrategy.java`**: 
  - Modified `writeFileToPath()` to skip checksum calculation when valid pre-calculated checksum exists
  - Replaced deprecated `DatatypeConverter.printHexBinary` with `HexFormat`
- **`EARKUtils.java`**: Updated all `addFileTypeFileToZip()` calls to pass checksum from `IPFile`

#### Bug Fix
Fixed a bug where `file.setChecksum(sip.getChecksum())` was overwriting the pre-calculated checksum with the algorithm name before it could be used. The fix saves the pre-calculated checksum values before this call.

### Usage Example

```java
// Create a file with pre-calculated checksum
IPFile representationFile = new IPFile(Paths.get("large_video.mkv"));
representationFile.setChecksum("ABC123DEF456...");  // Your pre-calculated checksum
representationFile.setChecksumAlgorithm("SHA-256");  // Must match SIP's algorithm
representation.addFile(representationFile);

// When building the SIP, the checksum won't be recalculated
Path sipPath = sip.build(writeStrategy);
```

### Testing
Added `testPreCalculatedChecksumSupport()` test that:
1. Sets a **fake checksum** on an `IPFile`
2. Builds a SIP
3. Extracts the SIP and verifies the fake checksum appears in the METS file
4. This proves the library uses the pre-calculated value rather than calculating