### PR TITLE
Fix parsing of content type fields from METS

### DIFF
--- a/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
@@ -8,7 +8,6 @@
 
 package org.roda_project.commons_ip2.model.impl.eark;
 
-import jakarta.xml.bind.JAXBException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -19,7 +18,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import javax.xml.namespace.QName;
+
 import org.apache.commons.lang3.StringUtils;
 import org.roda_project.commons_ip.model.ParseException;
 import org.roda_project.commons_ip.utils.IPEnums;
@@ -64,28 +65,41 @@ import org.roda_project.commons_ip2.utils.ZIPUtils;
 import org.slf4j.Logger;
 import org.xml.sax.SAXException;
 
+import jakarta.xml.bind.JAXBException;
+
+/**
+ * E-ARK common utility methods.
+ */
 public class EARKUtils {
 
+  /** METS generator used by utilities. */
   private final EARKMETSCreator metsGenerator;
+  /** Marker for OTHER values in METS attributes. */
   private static final String OTHER = "OTHER";
 
-  public EARKUtils(EARKMETSCreator metsGenerator) {
+  /**
+   * Creates a new utility helper bound to a METS generator.
+   *
+   * @param metsGenerator
+   *          generator used to build METS content
+   */
+  public EARKUtils(final EARKMETSCreator metsGenerator) {
     this.metsGenerator = metsGenerator;
   }
 
-  protected void addDescriptiveMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-                                                    List<IPDescriptiveMetadata> descriptiveMetadata, String representationId)
-      throws IPException, InterruptedException {
+  protected void addDescriptiveMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
+      final MetsWrapper metsWrapper, final List<IPDescriptiveMetadata> descriptiveMetadata,
+      final String representationId) throws IPException, InterruptedException {
     if (descriptiveMetadata != null && !descriptiveMetadata.isEmpty()) {
-      for (IPDescriptiveMetadata dm : descriptiveMetadata) {
+      for (final IPDescriptiveMetadata dm : descriptiveMetadata) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
-        IPFileInterface file = dm.getMetadata();
+        final IPFileInterface file = dm.getMetadata();
 
         String descriptiveFilePath = IPConstants.DESCRIPTIVE_FOLDER
             + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
-        MdRef mdRef = metsGenerator.addDescriptiveMetadataToMETS(metsWrapper, dm, descriptiveFilePath);
+        final MdRef mdRef = metsGenerator.addDescriptiveMetadataToMETS(metsWrapper, dm, descriptiveFilePath);
 
         if (representationId != null) {
           descriptiveFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
@@ -96,18 +110,19 @@ public class EARKUtils {
     }
   }
 
-  protected void addPreservationMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-                                                     List<IPMetadata> preservationMetadata, String representationId) throws IPException, InterruptedException {
+  protected void addPreservationMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
+      final MetsWrapper metsWrapper, final List<IPMetadata> preservationMetadata, final String representationId)
+      throws IPException, InterruptedException {
     if (preservationMetadata != null && !preservationMetadata.isEmpty()) {
-      for (IPMetadata pm : preservationMetadata) {
+      for (final IPMetadata pm : preservationMetadata) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
-        IPFileInterface file = pm.getMetadata();
+        final IPFileInterface file = pm.getMetadata();
 
         String preservationMetadataPath = IPConstants.PRESERVATION_FOLDER
             + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
-        MdRef mdRef = metsGenerator.addPreservationMetadataToMETS(metsWrapper, pm, preservationMetadataPath);
+        final MdRef mdRef = metsGenerator.addPreservationMetadataToMETS(metsWrapper, pm, preservationMetadataPath);
 
         if (representationId != null) {
           preservationMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId
@@ -118,40 +133,42 @@ public class EARKUtils {
     }
   }
 
-  protected void addOtherMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-                                              List<IPMetadata> otherMetadata, String representationId) throws IPException, InterruptedException {
+  protected void addOtherMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
+      final MetsWrapper metsWrapper, final List<IPMetadata> otherMetadata, final String representationId)
+      throws IPException, InterruptedException {
     if (otherMetadata != null && !otherMetadata.isEmpty()) {
-      for (IPMetadata om : otherMetadata) {
+      for (final IPMetadata om : otherMetadata) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
-        IPFileInterface file = om.getMetadata();
+        final IPFileInterface file = om.getMetadata();
 
-        String otherMetadataPath = IPConstants.OTHER_FOLDER + ModelUtils.getFoldersFromList(file.getRelativeFolders())
-            + file.getFileName();
-        MdRef mdRef = metsGenerator.addOtherMetadataToMETS(metsWrapper, om, otherMetadataPath);
+        String otherMetadataPath = IPConstants.OTHER_FOLDER
+            + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
+        final MdRef mdRef = metsGenerator.addOtherMetadataToMETS(metsWrapper, om, otherMetadataPath);
 
         if (representationId != null) {
-          otherMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-              + otherMetadataPath;
+          otherMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId
+              + IPConstants.ZIP_PATH_SEPARATOR + otherMetadataPath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), otherMetadataPath, mdRef);
       }
     }
   }
 
-  protected void addTechnicalMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-                                                  List<IPMetadata> technicalMetadata, String representationId) throws IPException, InterruptedException {
+  protected void addTechnicalMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
+      final MetsWrapper metsWrapper, final List<IPMetadata> technicalMetadata, final String representationId)
+      throws IPException, InterruptedException {
     if (technicalMetadata != null && !technicalMetadata.isEmpty()) {
-      for (IPMetadata tm : technicalMetadata) {
+      for (final IPMetadata tm : technicalMetadata) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
-        IPFileInterface file = tm.getMetadata();
+        final IPFileInterface file = tm.getMetadata();
 
         String technicalMetadataPath = IPConstants.TECHNICAL_FOLDER
             + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
-        MdRef mdRef = metsGenerator.addTechnicalMetadataToMETS(metsWrapper, tm, technicalMetadataPath);
+        final MdRef mdRef = metsGenerator.addTechnicalMetadataToMETS(metsWrapper, tm, technicalMetadataPath);
 
         if (representationId != null) {
           technicalMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
@@ -162,77 +179,83 @@ public class EARKUtils {
     }
   }
 
-  protected void addSourceMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-                                               List<IPMetadata> sourceMetadata, String representationId) throws IPException, InterruptedException {
+  protected void addSourceMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
+      final MetsWrapper metsWrapper, final List<IPMetadata> sourceMetadata, final String representationId)
+      throws IPException, InterruptedException {
     if (sourceMetadata != null && !sourceMetadata.isEmpty()) {
-      for (IPMetadata sm : sourceMetadata) {
+      for (final IPMetadata sm : sourceMetadata) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
-        IPFileInterface file = sm.getMetadata();
+        final IPFileInterface file = sm.getMetadata();
 
-        String sourceMetadataPath = IPConstants.SOURCE_FOLDER + ModelUtils.getFoldersFromList(file.getRelativeFolders())
-            + file.getFileName();
-        MdRef mdRef = metsGenerator.addSourceMetadataToMETS(metsWrapper, sm, sourceMetadataPath);
+        String sourceMetadataPath = IPConstants.SOURCE_FOLDER
+            + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
+        final MdRef mdRef = metsGenerator.addSourceMetadataToMETS(metsWrapper, sm, sourceMetadataPath);
 
         if (representationId != null) {
-          sourceMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-              + sourceMetadataPath;
+          sourceMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId
+              + IPConstants.ZIP_PATH_SEPARATOR + sourceMetadataPath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), sourceMetadataPath, mdRef);
       }
     }
   }
 
-  protected void addRightsMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-                                               List<IPMetadata> rightsMetadata, String representationId) throws IPException, InterruptedException {
+  protected void addRightsMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
+      final MetsWrapper metsWrapper, final List<IPMetadata> rightsMetadata, final String representationId)
+      throws IPException, InterruptedException {
     if (rightsMetadata != null && !rightsMetadata.isEmpty()) {
-      for (IPMetadata rm : rightsMetadata) {
+      for (final IPMetadata rm : rightsMetadata) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
-        IPFileInterface file = rm.getMetadata();
+        final IPFileInterface file = rm.getMetadata();
 
-        String rightsMetadataPath = IPConstants.RIGHTS_FOLDER + ModelUtils.getFoldersFromList(file.getRelativeFolders())
-            + file.getFileName();
-        MdRef mdRef = metsGenerator.addRightsMetadataToMETS(metsWrapper, rm, rightsMetadataPath);
+        String rightsMetadataPath = IPConstants.RIGHTS_FOLDER
+            + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
+        final MdRef mdRef = metsGenerator.addRightsMetadataToMETS(metsWrapper, rm, rightsMetadataPath);
 
         if (representationId != null) {
-          rightsMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-              + rightsMetadataPath;
+          rightsMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId
+              + IPConstants.ZIP_PATH_SEPARATOR + rightsMetadataPath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), rightsMetadataPath, mdRef);
       }
     }
   }
 
-  protected void addRepresentationsToZipAndMETS(IPInterface ip, List<IPRepresentation> representations,
-                                                Map<String, ZipEntryInfo> zipEntries, MetsWrapper mainMETSWrapper, Path buildDir, IPEnums.SipType sipType)
+  protected void addRepresentationsToZipAndMETS(final IPInterface ip,
+      final List<IPRepresentation> representations, final Map<String, ZipEntryInfo> zipEntries,
+      final MetsWrapper mainMETSWrapper, final Path buildDir, final IPEnums.SipType sipType)
       throws IPException, InterruptedException {
     // representations
     if (representations != null && !representations.isEmpty()) {
       if (ip instanceof SIP) {
         ((SIP) ip).notifySipBuildRepresentationsProcessingStarted(representations.size());
       }
-      for (IPRepresentation representation : representations) {
+      for (final IPRepresentation representation : representations) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
-        String representationId = representation.getObjectID();
+        final String representationId = representation.getObjectID();
         // 20160407 hsilva: not being used by Common Specification v0.13
-        final boolean isRepresentationMetadataOther = (representation.getOtherMetadata() != null
-            && !representation.getOtherMetadata().isEmpty());
-        final boolean isRepresentationMetadata = ((representation.getDescriptiveMetadata() != null
+        final boolean isRepresentationMetadataOther = representation.getOtherMetadata() != null
+            && !representation.getOtherMetadata().isEmpty();
+        final boolean isRepresentationMetadata = (representation.getDescriptiveMetadata() != null
             && !representation.getDescriptiveMetadata().isEmpty())
-            || (representation.getPreservationMetadata() != null && !representation.getPreservationMetadata().isEmpty()));
-        final boolean isRepresentationDocumentation = (representation.getDocumentation() != null
-            && !representation.getDocumentation().isEmpty());
-        final boolean isRepresentationSchemas = (representation.getSchemas() != null
-            && !representation.getSchemas().isEmpty());
-        final boolean isRepresentationsData = (representation.getData() != null && !representation.getData().isEmpty());
+            || (representation.getPreservationMetadata() != null
+                && !representation.getPreservationMetadata().isEmpty());
+        final boolean isRepresentationDocumentation = representation.getDocumentation() != null
+            && !representation.getDocumentation().isEmpty();
+        final boolean isRepresentationSchemas = representation.getSchemas() != null
+            && !representation.getSchemas().isEmpty();
+        final boolean isRepresentationsData = representation.getData() != null
+            && !representation.getData().isEmpty();
         final IPHeader header = new IPHeader(IPEnums.IPStatus.NEW).setAgents(representation.getAgents());
         final MetsWrapper representationMETSWrapper;
 
+        final String siardProfile = "https://citssiard.dilcis.eu/profile/E-ARK-SIARD-REPRESENTATION.xml";
         if (IPEnums.SipType.ERMS.equals(sipType)) {
           representationMETSWrapper = metsGenerator.generateMETS(representationId, representation.getDescription(),
               ip.getProfile(), false, Optional.empty(), null, header,
@@ -242,7 +265,7 @@ public class EARKUtils {
         } else if (IPEnums.SipType.SIARD.equals(sipType)) {
           representation.setContentInformationType(representation.getContentInformationType());
           representationMETSWrapper = metsGenerator.generateMetsSiard(representationId, representation.getDescription(),
-              "https://citssiard.dilcis.eu/profile/E-ARK-SIARD-REPRESENTATION.xml", false, Optional.empty(), null, header,
+              siardProfile, false, Optional.empty(), null, header,
               mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(), representation.getContentType(),
               representation.getContentInformationType(), isRepresentationMetadata, isRepresentationMetadataOther,
               isRepresentationSchemas, isRepresentationDocumentation, false, false, isRepresentationsData);

--- a/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
@@ -72,24 +72,53 @@ import jakarta.xml.bind.JAXBException;
  */
 public class EARKUtils {
 
-  /** METS generator used by utilities. */
-  private final EARKMETSCreator metsGenerator;
-  /** Marker for OTHER values in METS attributes. */
+  /**
+   * Marker for OTHER values in METS attributes.
+   */
   private static final String OTHER = "OTHER";
+  /**
+   * Slash used in METS labels.
+   */
+  private static final String SLASH = "/";
+  /**
+   * Log message for validated metadata type.
+   */
+  private static final String METADATA_TYPE_VALID_MSG = "Metadata type valid: {}";
+  /**
+   * Log message for fallback metadata type.
+   */
+  private static final String SETTING_METADATA_TYPE_MSG = "Setting metadata type to {}";
+  /**
+   * Prefix for fallback metadata type in validation entry.
+   */
+  private static final String SETTING_METADATA_TYPE_PREFIX = "Setting metadata type to ";
+  /**
+   * Prefix for unknown metadata type error.
+   */
+  private static final String UNKNOWN_METADATA_TYPE_PREFIX = "Unknown metadata type: ";
+  /**
+   * Suffix for OAIS package type error messages.
+   */
+  private static final String OAIS_PACKAGE_TYPE_SUFFIX = "'.";
+  /**
+   * METS generator used by utilities.
+   */
+  private final EARKMETSCreator metsGenerator;
 
   /**
    * Creates a new utility helper bound to a METS generator.
    *
-   * @param metsGenerator
-   *          generator used to build METS content
+   * @param metsGenerator generator used to build METS content
    */
   public EARKUtils(final EARKMETSCreator metsGenerator) {
     this.metsGenerator = metsGenerator;
   }
 
   protected void addDescriptiveMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
-      final MetsWrapper metsWrapper, final List<IPDescriptiveMetadata> descriptiveMetadata,
-      final String representationId) throws IPException, InterruptedException {
+                                                    final MetsWrapper metsWrapper,
+                                                    final List<IPDescriptiveMetadata> descriptiveMetadata,
+                                                    final String representationId)
+      throws IPException, InterruptedException {
     if (descriptiveMetadata != null && !descriptiveMetadata.isEmpty()) {
       for (final IPDescriptiveMetadata dm : descriptiveMetadata) {
         if (Thread.interrupted()) {
@@ -111,7 +140,9 @@ public class EARKUtils {
   }
 
   protected void addPreservationMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
-      final MetsWrapper metsWrapper, final List<IPMetadata> preservationMetadata, final String representationId)
+                                                     final MetsWrapper metsWrapper,
+                                                     final List<IPMetadata> preservationMetadata,
+                                                     final String representationId)
       throws IPException, InterruptedException {
     if (preservationMetadata != null && !preservationMetadata.isEmpty()) {
       for (final IPMetadata pm : preservationMetadata) {
@@ -134,7 +165,8 @@ public class EARKUtils {
   }
 
   protected void addOtherMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
-      final MetsWrapper metsWrapper, final List<IPMetadata> otherMetadata, final String representationId)
+                                              final MetsWrapper metsWrapper, final List<IPMetadata> otherMetadata,
+                                              final String representationId)
       throws IPException, InterruptedException {
     if (otherMetadata != null && !otherMetadata.isEmpty()) {
       for (final IPMetadata om : otherMetadata) {
@@ -157,7 +189,9 @@ public class EARKUtils {
   }
 
   protected void addTechnicalMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
-      final MetsWrapper metsWrapper, final List<IPMetadata> technicalMetadata, final String representationId)
+                                                  final MetsWrapper metsWrapper,
+                                                  final List<IPMetadata> technicalMetadata,
+                                                  final String representationId)
       throws IPException, InterruptedException {
     if (technicalMetadata != null && !technicalMetadata.isEmpty()) {
       for (final IPMetadata tm : technicalMetadata) {
@@ -180,7 +214,8 @@ public class EARKUtils {
   }
 
   protected void addSourceMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
-      final MetsWrapper metsWrapper, final List<IPMetadata> sourceMetadata, final String representationId)
+                                               final MetsWrapper metsWrapper, final List<IPMetadata> sourceMetadata,
+                                               final String representationId)
       throws IPException, InterruptedException {
     if (sourceMetadata != null && !sourceMetadata.isEmpty()) {
       for (final IPMetadata sm : sourceMetadata) {
@@ -203,7 +238,8 @@ public class EARKUtils {
   }
 
   protected void addRightsMetadataToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
-      final MetsWrapper metsWrapper, final List<IPMetadata> rightsMetadata, final String representationId)
+                                               final MetsWrapper metsWrapper, final List<IPMetadata> rightsMetadata,
+                                               final String representationId)
       throws IPException, InterruptedException {
     if (rightsMetadata != null && !rightsMetadata.isEmpty()) {
       for (final IPMetadata rm : rightsMetadata) {
@@ -226,8 +262,10 @@ public class EARKUtils {
   }
 
   protected void addRepresentationsToZipAndMETS(final IPInterface ip,
-      final List<IPRepresentation> representations, final Map<String, ZipEntryInfo> zipEntries,
-      final MetsWrapper mainMETSWrapper, final Path buildDir, final IPEnums.SipType sipType)
+                                                final List<IPRepresentation> representations,
+                                                final Map<String, ZipEntryInfo> zipEntries,
+                                                final MetsWrapper mainMETSWrapper, final Path buildDir,
+                                                final IPEnums.SipType sipType)
       throws IPException, InterruptedException {
     // representations
     if (representations != null && !representations.isEmpty()) {
@@ -242,10 +280,10 @@ public class EARKUtils {
         // 20160407 hsilva: not being used by Common Specification v0.13
         final boolean isRepresentationMetadataOther = representation.getOtherMetadata() != null
             && !representation.getOtherMetadata().isEmpty();
-        final boolean isRepresentationMetadata = (representation.getDescriptiveMetadata() != null
-            && !representation.getDescriptiveMetadata().isEmpty())
-            || (representation.getPreservationMetadata() != null
-                && !representation.getPreservationMetadata().isEmpty());
+        final boolean isRepresentationMetadata = representation.getDescriptiveMetadata() != null
+            && !representation.getDescriptiveMetadata().isEmpty()
+            || representation.getPreservationMetadata() != null
+            && !representation.getPreservationMetadata().isEmpty();
         final boolean isRepresentationDocumentation = representation.getDocumentation() != null
             && !representation.getDocumentation().isEmpty();
         final boolean isRepresentationSchemas = representation.getSchemas() != null
@@ -357,28 +395,32 @@ public class EARKUtils {
 
   }
 
-  private void addRepresentationDataFilesToZipErmsAndMETS(IPInterface ip, Map<String, ZipEntryInfo> zipEntries,
-                                                          MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
+  private void addRepresentationDataFilesToZipErmsAndMETS(final IPInterface ip,
+                                                          final Map<String, ZipEntryInfo> zipEntries,
+                                                          final MetsWrapper representationMETSWrapper,
+                                                          final IPRepresentation representation,
+                                                          final String representationId)
       throws InterruptedException, IPException {
     if (representation.getData() != null && !representation.getData().isEmpty()) {
       if (ip instanceof SIP sip) {
         sip.notifySipBuildRepresentationProcessingStarted(representation.getData().size());
       }
       int i = 0;
-      for (IPFileInterface file : representation.getData()) {
+      for (final IPFileInterface file : representation.getData()) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
 
         if (file instanceof IPFile) {
           String dataFilePath = ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
-          FileType fileType = metsGenerator.addDataFileToMETS(representationMETSWrapper, dataFilePath, file.getPath());
+          final FileType fileType = metsGenerator.addDataFileToMETS(representationMETSWrapper, dataFilePath,
+              file.getPath());
 
           dataFilePath = IPConstants.DATA_FOLDER + dataFilePath;
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
               + dataFilePath;
           ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
-        } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
+        } else if (file instanceof IPFileShallow shallow && shallow.getFileLocation() != null) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
         }
 
@@ -394,22 +436,26 @@ public class EARKUtils {
 
   }
 
-  private void addRepresentationDataFilesToZipSiardAndMETS(IPInterface ip, Map<String, ZipEntryInfo> zipEntries,
-                                                           MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
+  private void addRepresentationDataFilesToZipSiardAndMETS(final IPInterface ip,
+                                                           final Map<String, ZipEntryInfo> zipEntries,
+                                                           final MetsWrapper representationMETSWrapper,
+                                                           final IPRepresentation representation,
+                                                           final String representationId)
       throws InterruptedException, IPException {
     if (representation.getData() != null && !representation.getData().isEmpty()) {
       if (ip instanceof SIP sip) {
         sip.notifySipBuildRepresentationProcessingStarted(representation.getData().size());
       }
       int i = 0;
-      for (IPFileInterface file : representation.getData()) {
+      for (final IPFileInterface file : representation.getData()) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
 
         if (file instanceof IPFile) {
           String dataFilePath = ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
-          FileType fileType = metsGenerator.addDataFileToMETS(representationMETSWrapper, dataFilePath, file.getPath());
+          final FileType fileType = metsGenerator.addDataFileToMETS(representationMETSWrapper, dataFilePath,
+              file.getPath());
           if (representation.getContentInformationType().getOtherType() != null) {
             fileType.getOtherAttributes().put(QName.valueOf("csip:OTHERCONTENTINFORMATIONTYPE"),
                 representation.getContentInformationType().getOtherType());
@@ -418,7 +464,7 @@ public class EARKUtils {
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
               + dataFilePath;
           ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
-        } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
+        } else if (file instanceof IPFileShallow shallow && shallow.getFileLocation() != null) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
         }
 
@@ -433,15 +479,18 @@ public class EARKUtils {
     }
   }
 
-  protected void addRepresentationDataFilesToZipAndMETS(IPInterface ip, Map<String, ZipEntryInfo> zipEntries,
-                                                        MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
+  protected void addRepresentationDataFilesToZipAndMETS(final IPInterface ip,
+                                                        final Map<String, ZipEntryInfo> zipEntries,
+                                                        final MetsWrapper representationMETSWrapper,
+                                                        final IPRepresentation representation,
+                                                        final String representationId)
       throws IPException, InterruptedException {
     if (representation.getData() != null && !representation.getData().isEmpty()) {
       if (ip instanceof SIP sip) {
         sip.notifySipBuildRepresentationProcessingStarted(representation.getData().size());
       }
       int i = 0;
-      for (IPFileInterface file : representation.getData()) {
+      for (final IPFileInterface file : representation.getData()) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
@@ -449,12 +498,13 @@ public class EARKUtils {
         if (file instanceof IPFile) {
           String dataFilePath = IPConstants.DATA_FOLDER + ModelUtils.getFoldersFromList(file.getRelativeFolders())
               + file.getFileName();
-          FileType fileType = metsGenerator.addDataFileToMETS(representationMETSWrapper, dataFilePath, file.getPath());
+          final FileType fileType = metsGenerator.addDataFileToMETS(representationMETSWrapper, dataFilePath,
+              file.getPath());
 
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
               + dataFilePath;
           ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
-        } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
+        } else if (file instanceof IPFileShallow shallow && shallow.getFileLocation() != null) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
         }
 
@@ -469,17 +519,18 @@ public class EARKUtils {
     }
   }
 
-  protected void addSchemasToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-                                        List<IPFileInterface> schemas, String representationId) throws IPException, InterruptedException {
+  protected void addSchemasToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries, final MetsWrapper metsWrapper,
+                                        final List<IPFileInterface> schemas, final String representationId)
+      throws IPException, InterruptedException {
     if (schemas != null && !schemas.isEmpty()) {
-      for (IPFileInterface schema : schemas) {
+      for (final IPFileInterface schema : schemas) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
 
         String schemaFilePath = IPConstants.SCHEMAS_FOLDER + ModelUtils.getFoldersFromList(schema.getRelativeFolders())
             + schema.getFileName();
-        FileType fileType = metsGenerator.addSchemaFileToMETS(metsWrapper, schemaFilePath, schema.getPath());
+        final FileType fileType = metsGenerator.addSchemaFileToMETS(metsWrapper, schemaFilePath, schema.getPath());
 
         if (representationId != null) {
           schemaFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
@@ -490,17 +541,20 @@ public class EARKUtils {
     }
   }
 
-  protected void addDocumentationToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-                                              List<IPFileInterface> documentation, String representationId) throws IPException, InterruptedException {
+  protected void addDocumentationToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries,
+                                              final MetsWrapper metsWrapper, final List<IPFileInterface> documentation,
+                                              final String representationId)
+      throws IPException, InterruptedException {
     if (documentation != null && !documentation.isEmpty()) {
-      for (IPFileInterface doc : documentation) {
+      for (final IPFileInterface doc : documentation) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
 
         String documentationFilePath = IPConstants.DOCUMENTATION_FOLDER
             + ModelUtils.getFoldersFromList(doc.getRelativeFolders()) + doc.getFileName();
-        FileType fileType = metsGenerator.addDocumentationFileToMETS(metsWrapper, documentationFilePath, doc.getPath());
+        final FileType fileType = metsGenerator.addDocumentationFileToMETS(metsWrapper, documentationFilePath,
+            doc.getPath());
 
         if (representationId != null) {
           documentationFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
@@ -511,7 +565,8 @@ public class EARKUtils {
     }
   }
 
-  protected void addDefaultSchemas(Logger logger, List<IPFileInterface> schemas, Path buildDir, Boolean override)
+  protected void addDefaultSchemas(final Logger logger, final List<IPFileInterface> schemas, final Path buildDir,
+                                   final Boolean override)
       throws InterruptedException {
     try {
       if (Thread.interrupted()) {
@@ -534,36 +589,37 @@ public class EARKUtils {
         }
       }
 
-      Path earkCsipSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
+      final Path earkCsipSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
           IPConstants.SCHEMA_EARK_CSIP_FILENAME, IPConstants.SCHEMA_EARK_CSIP_RELATIVE_PATH_FROM_RESOURCES);
       if (!tempSchema.equals(IPConstants.SCHEMA_EARK_CSIP_FILENAME)) {
         schemas.add(new IPFile(earkCsipSchema, IPConstants.SCHEMA_EARK_CSIP_FILENAME));
       }
-      Path earkSipSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
+      final Path earkSipSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
           IPConstants.SCHEMA_EARK_SIP_FILENAME, IPConstants.SCHEMA_EARK_SIP_RELATIVE_PATH_FROM_RESOURCES);
       if (!tempSchema.equals(IPConstants.SCHEMA_EARK_SIP_FILENAME)) {
         schemas.add(new IPFile(earkSipSchema, IPConstants.SCHEMA_EARK_SIP_FILENAME));
       }
-      Path metsSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
+      final Path metsSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
           IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION, IPConstants.SCHEMA_METS_RELATIVE_PATH_FROM_RESOURCES);
       if (!tempSchema.equals(IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION)) {
         schemas.add(new IPFile(metsSchema, IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION));
       }
-      Path xlinkSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
+      final Path xlinkSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
           IPConstants.SCHEMA_XLINK_FILENAME, IPConstants.SCHEMA_XLINK_RELATIVE_PATH_FROM_RESOURCES);
       if (!tempSchema.equals(IPConstants.SCHEMA_XLINK_FILENAME)) {
         schemas.add(new IPFile(xlinkSchema, IPConstants.SCHEMA_XLINK_FILENAME));
       }
 
-    } catch (IOException e) {
+    } catch (final IOException e) {
       logger.error("Error while trying to add default schemas", e);
     }
   }
 
   protected void addSubmissionsToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries, final MetsWrapper metsWrapper,
-                                            final List<IPFileInterface> submissions) throws IPException, InterruptedException {
+                                            final List<IPFileInterface> submissions)
+      throws IPException, InterruptedException {
     if (submissions != null && !submissions.isEmpty()) {
-      for (IPFileInterface submission : submissions) {
+      for (final IPFileInterface submission : submissions) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
@@ -576,8 +632,8 @@ public class EARKUtils {
     }
   }
 
-  protected MetsWrapper processMainMets(IPInterface ip, Path ipPath) {
-    Path mainMETSFile = ipPath.resolve(IPConstants.METS_FILE);
+  protected MetsWrapper processMainMets(final IPInterface ip, final Path ipPath) {
+    final Path mainMETSFile = ipPath.resolve(IPConstants.METS_FILE);
     Mets mainMets = null;
     if (Files.exists(mainMETSFile)) {
       ValidationUtils.addInfo(ip.getValidationReport(), ValidationConstants.MAIN_METS_FILE_FOUND, ipPath, mainMETSFile);
@@ -592,7 +648,7 @@ public class EARKUtils {
         addAgentsToMETS(mainMets, ip, null);
 
         ValidationUtils.addInfo(ip.getValidationReport(), ValidationConstants.MAIN_METS_IS_VALID, ipPath, mainMETSFile);
-      } catch (JAXBException | ParseException | SAXException | IOException e) {
+      } catch (final JAXBException | ParseException | SAXException | IOException e) {
         mainMets = null;
         ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.MAIN_METS_NOT_VALID,
             ValidationEntry.LEVEL.ERROR, e, ip.getBasePath(), mainMETSFile);
@@ -604,24 +660,24 @@ public class EARKUtils {
     return new MetsWrapper(mainMets, mainMETSFile);
   }
 
-  protected void setIPContentType(Mets mets, IPInterface ip) throws ParseException {
-    String oaisPackageType = mets.getMetsHdr().getOAISPACKAGETYPE();
+  protected void setIPContentType(final Mets mets, final IPInterface ip) throws ParseException {
+    final String oaisPackageType = mets.getMetsHdr().getOAISPACKAGETYPE();
 
     if (StringUtils.isBlank(oaisPackageType)) {
       throw new ParseException("METS 'OAISPACKAGETYPE' attribute does not contain any value");
     }
 
     try {
-      IPEnums.IPType packageType = IPEnums.IPType.valueOf(oaisPackageType);
+      final IPEnums.IPType packageType = IPEnums.IPType.valueOf(oaisPackageType);
 
       if (ip instanceof SIP && IPEnums.IPType.SIP != packageType) {
-        throw new ParseException(
-            "METS 'OAISPACKAGETYPE' should have the value 'SIP' but it doesn't. Instead, it has '" + packageType + "'.");
+        throw new ParseException("METS 'OAISPACKAGETYPE' should have the value 'SIP' but it doesn't. Instead, it has '"
+            + packageType + OAIS_PACKAGE_TYPE_SUFFIX);
       } else if (ip instanceof AIP && IPEnums.IPType.AIP != packageType) {
-        throw new ParseException(
-            "METS 'OAISPACKAGETYPE' should have the value 'AIP' but it doesn't. Instead, it has '" + packageType + "'.");
+        throw new ParseException("METS 'OAISPACKAGETYPE' should have the value 'AIP' but it doesn't. Instead, it has '"
+            + packageType + OAIS_PACKAGE_TYPE_SUFFIX);
       }
-    } catch (IllegalArgumentException e) {
+    } catch (final IllegalArgumentException e) {
       throw new ParseException("METS 'OAISPACKAGETYPE' attribute does not contain a valid package type");
     }
 
@@ -665,9 +721,9 @@ public class EARKUtils {
     return new IPContentInformationType(contentInformationType);
   }
 
-  protected void addAgentsToMETS(Mets mets, IPInterface ip, IPRepresentation representation) {
+  protected void addAgentsToMETS(final Mets mets, final IPInterface ip, final IPRepresentation representation) {
     if (mets.getMetsHdr() != null && mets.getMetsHdr().getAgent() != null) {
-      for (Agent agent : mets.getMetsHdr().getAgent()) {
+      for (final Agent agent : mets.getMetsHdr().getAgent()) {
         if (representation == null) {
           ip.addAgent(metsGenerator.createIPAgent(ip, agent));
         } else {
@@ -677,8 +733,8 @@ public class EARKUtils {
     }
   }
 
-  protected MetsWrapper processRepresentationMets(IPInterface ip, Path representationMetsFile,
-                                                  IPRepresentation representation) {
+  protected MetsWrapper processRepresentationMets(final IPInterface ip, final Path representationMetsFile,
+                                                  final IPRepresentation representation) {
     Mets representationMets = null;
     if (Files.exists(representationMetsFile)) {
       ValidationUtils.addInfo(ip.getValidationReport(), ValidationConstants.REPRESENTATION_METS_FILE_FOUND,
@@ -689,7 +745,7 @@ public class EARKUtils {
         setRepresentationContentInformationType(representationMets, representation);
         ValidationUtils.addInfo(ip.getValidationReport(), ValidationConstants.REPRESENTATION_METS_IS_VALID,
             ip.getBasePath(), representationMetsFile);
-      } catch (JAXBException | ParseException | SAXException | IOException e) {
+      } catch (final JAXBException | ParseException | SAXException | IOException e) {
         representationMets = null;
         ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.REPRESENTATION_METS_NOT_VALID,
             ValidationEntry.LEVEL.ERROR, e, ip.getBasePath(), representationMetsFile);
@@ -717,25 +773,27 @@ public class EARKUtils {
     representation.setContentInformationType(ipContentInformationType);
   }
 
-  protected IPInterface processRepresentations(MetsWrapper metsWrapper, IPInterface ip, Logger logger)
+  protected IPInterface processRepresentations(final MetsWrapper metsWrapper, final IPInterface ip,
+                                               final Logger logger)
       throws IPException {
 
     if (metsWrapper.getMainDiv() != null && metsWrapper.getMainDiv().getDiv() != null) {
-      for (DivType div : metsWrapper.getMainDiv().getDiv()) {
+      for (final DivType div : metsWrapper.getMainDiv().getDiv()) {
         if (div.getLABEL().startsWith(IPConstants.REPRESENTATIONS_WITH_FIRST_LETTER_CAPITAL)
-            && (div.getMptr() != null && !div.getMptr().isEmpty())) {
+            && div.getMptr() != null && !div.getMptr().isEmpty()) {
           // we can assume one and only one mets for each representation div
-          Mptr mptr = div.getMptr().get(0);
-          String href = Utils.extractedRelativePathFromHref(mptr.getHref());
-          Path metsFilePath = ip.getBasePath().resolve(href);
-          IPRepresentation representation = new IPRepresentation(
-              div.getLABEL().replaceFirst(IPConstants.REPRESENTATIONS_WITH_FIRST_LETTER_CAPITAL + "/", ""));
-          MetsWrapper representationMetsWrapper = processRepresentationMets(ip, metsFilePath, representation);
+          final Mptr mptr = div.getMptr().get(0);
+          final String href = Utils.extractedRelativePathFromHref(mptr.getHref());
+          final Path metsFilePath = ip.getBasePath().resolve(href);
+          final IPRepresentation representation = new IPRepresentation(
+              div.getLABEL()
+                  .replaceFirst(IPConstants.REPRESENTATIONS_WITH_FIRST_LETTER_CAPITAL + SLASH, ""));
+          final MetsWrapper representationMetsWrapper = processRepresentationMets(ip, metsFilePath, representation);
 
           if (representationMetsWrapper.getMets() != null) {
-            Path representationBasePath = metsFilePath.getParent();
+            final Path representationBasePath = metsFilePath.getParent();
 
-            StructMapType representationStructMap = getEARKStructMap(representationMetsWrapper, ip, false);
+            final StructMapType representationStructMap = getEARKStructMap(representationMetsWrapper, ip, false);
             if (representationStructMap != null) {
 
               preProcessStructMap(representationMetsWrapper, representationStructMap);
@@ -788,10 +846,11 @@ public class EARKUtils {
 
   }
 
-  protected StructMapType getEARKStructMap(MetsWrapper metsWrapper, IPInterface ip, boolean mainMets) {
-    Mets mets = metsWrapper.getMets();
+  protected StructMapType getEARKStructMap(final MetsWrapper metsWrapper, final IPInterface ip,
+                                           final boolean mainMets) {
+    final Mets mets = metsWrapper.getMets();
     StructMapType res = null;
-    for (StructMapType structMap : mets.getStructMap()) {
+    for (final StructMapType structMap : mets.getStructMap()) {
       if (StringUtils.equals(structMap.getLABEL(), IPConstants.COMMON_SPEC_STRUCTURAL_MAP)) {
         res = structMap;
         break;
@@ -811,15 +870,15 @@ public class EARKUtils {
     return res;
   }
 
-  protected void preProcessStructMap(MetsWrapper metsWrapper, StructMapType structMap) {
+  protected void preProcessStructMap(final MetsWrapper metsWrapper, final StructMapType structMap) {
 
-    DivType ipDiv = structMap.getDiv();
+    final DivType ipDiv = structMap.getDiv();
     if (ipDiv.getDiv() != null) {
       metsWrapper.setMainDiv(ipDiv);
-      for (DivType firstLevel : ipDiv.getDiv()) {
+      for (final DivType firstLevel : ipDiv.getDiv()) {
         if (IPConstants.METADATA.equalsIgnoreCase(firstLevel.getLABEL()) && firstLevel.getDiv() != null) {
           metsWrapper.setMetadataDiv(firstLevel);
-        } else if ((IPConstants.METADATA + "/" + IPConstants.OTHER).equalsIgnoreCase(firstLevel.getLABEL())) {
+        } else if ((IPConstants.METADATA + SLASH + IPConstants.OTHER).equalsIgnoreCase(firstLevel.getLABEL())) {
           metsWrapper.setOtherMetadataDiv(firstLevel);
         } else if (IPConstants.DATA.equalsIgnoreCase(firstLevel.getLABEL())) {
           metsWrapper.setDataDiv(firstLevel);
@@ -834,43 +893,45 @@ public class EARKUtils {
     }
   }
 
-  protected void processDescriptiveMetadata(MetsWrapper metsWrapper, IPInterface ip, Logger logger,
-                                            IPRepresentation representation, Path basePath) throws IPException {
-    String metadataType = IPConstants.DESCRIPTIVE;
-    List<MdSecType> dmdSec = metsWrapper.getMets().getDmdSec();
-    for (MdSecType mdSecType : dmdSec) {
-      MdRef mdRef = mdSecType.getMdRef();
+  protected void processDescriptiveMetadata(final MetsWrapper metsWrapper, final IPInterface ip, final Logger logger,
+                                            final IPRepresentation representation, final Path basePath)
+      throws IPException {
+    final String metadataType = IPConstants.DESCRIPTIVE;
+    final List<MdSecType> dmdSec = metsWrapper.getMets().getDmdSec();
+    for (final MdSecType mdSecType : dmdSec) {
+      final MdRef mdRef = mdSecType.getMdRef();
       if (mdRef != null) {
-        String href = Utils.extractedRelativePathFromHref(mdRef);
-        Path filePath = basePath.resolve(href);
+        final String href = Utils.extractedRelativePathFromHref(mdRef);
+        final Path filePath = basePath.resolve(href);
         if (Files.exists(filePath)) {
-          List<String> fileRelativeFolders = Utils
+          final List<String> fileRelativeFolders = Utils
               .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
 
-          Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef, fileRelativeFolders);
+          final Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef,
+              fileRelativeFolders);
           if (metadataFile.isPresent()) {
             ValidationUtils.addInfo(ip.getValidationReport(),
                 ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(),
                 filePath);
 
-            MetadataType dmdType = new MetadataType(mdRef.getMDTYPE().toUpperCase());
+            final MetadataType dmdType = new MetadataType(mdRef.getMDTYPE().toUpperCase());
             String dmdVersion = null;
             try {
               dmdVersion = mdRef.getMDTYPEVERSION();
               if (StringUtils.isNotBlank(mdRef.getOTHERMDTYPE())) {
                 dmdType.setOtherType(mdRef.getOTHERMDTYPE());
               }
-              logger.debug("Metadata type valid: {}", dmdType);
-            } catch (NullPointerException | IllegalArgumentException e) {
+              logger.debug(METADATA_TYPE_VALID_MSG, dmdType);
+            } catch (final NullPointerException | IllegalArgumentException e) {
               // do nothing and use already defined values for metadataType &
               // metadataVersion
-              logger.debug("Setting metadata type to {}", dmdType);
+              logger.debug(SETTING_METADATA_TYPE_MSG, dmdType);
               ValidationUtils.addEntry(ip.getValidationReport(), ValidationConstants.UNKNOWN_DESCRIPTIVE_METADATA_TYPE,
-                  ValidationEntry.LEVEL.WARN, "Setting metadata type to " + dmdType, ip.getBasePath(), filePath);
+                  ValidationEntry.LEVEL.WARN, SETTING_METADATA_TYPE_PREFIX + dmdType, ip.getBasePath(), filePath);
             }
 
-            IPDescriptiveMetadata descriptiveMetadata = new IPDescriptiveMetadata(mdRef.getID(), metadataFile.get(),
-                dmdType, dmdVersion);
+            final IPDescriptiveMetadata descriptiveMetadata = new IPDescriptiveMetadata(mdRef.getID(),
+                metadataFile.get(), dmdType, dmdVersion);
             descriptiveMetadata.setCreateDate(mdRef.getCREATED());
             if (representation == null) {
               ip.addDescriptiveMetadata(descriptiveMetadata);
@@ -887,76 +948,78 @@ public class EARKUtils {
     }
   }
 
-  protected void processOtherMetadata(MetsWrapper metsWrapper, IPInterface ip, Logger logger,
-                                      IPRepresentation representation, Path basePath) throws IPException {
+  protected void processOtherMetadata(final MetsWrapper metsWrapper, final IPInterface ip, final Logger logger,
+                                      final IPRepresentation representation, final Path basePath) throws IPException {
 
     processMetadata(ip, logger, representation, metsWrapper.getOtherMetadataDiv(), IPConstants.OTHER, basePath);
   }
 
-  protected void processPreservationMetadata(MetsWrapper metsWrapper, IPInterface ip, IPRepresentation representation,
-                                             Path basePath) throws IPException {
-    String metadataType = IPConstants.PRESERVATION;
-    for (AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
-      for (MdSecType mdSecType : amdSecType.getDigiprovMD()) {
-        MdRef mdRef = mdSecType.getMdRef();
+  protected void processPreservationMetadata(final MetsWrapper metsWrapper, final IPInterface ip,
+                                             final IPRepresentation representation, final Path basePath)
+      throws IPException {
+    final String metadataType = IPConstants.PRESERVATION;
+    for (final AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
+      for (final MdSecType mdSecType : amdSecType.getDigiprovMD()) {
+        final MdRef mdRef = mdSecType.getMdRef();
 
         processMdRef(mdRef, metadataType, ip, representation, basePath);
       }
     }
   }
 
-  protected void processTechnicalMetadata(MetsWrapper metsWrapper, IPInterface ip, IPRepresentation representation,
-                                          Path basePath) throws IPException {
-    String metadataType = IPConstants.TECHNICAL;
-    for (AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
-      for (MdSecType mdSecType : amdSecType.getTechMD()) {
-        MdRef mdRef = mdSecType.getMdRef();
+  protected void processTechnicalMetadata(final MetsWrapper metsWrapper, final IPInterface ip,
+                                          final IPRepresentation representation, final Path basePath)
+      throws IPException {
+    final String metadataType = IPConstants.TECHNICAL;
+    for (final AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
+      for (final MdSecType mdSecType : amdSecType.getTechMD()) {
+        final MdRef mdRef = mdSecType.getMdRef();
 
         processMdRef(mdRef, metadataType, ip, representation, basePath);
       }
     }
   }
 
-  protected void processSourceMetadata(MetsWrapper metsWrapper, IPInterface ip, IPRepresentation representation,
-                                       Path basePath) throws IPException {
+  protected void processSourceMetadata(final MetsWrapper metsWrapper, final IPInterface ip,
+                                       final IPRepresentation representation, final Path basePath) throws IPException {
 
-    String metadataType = IPConstants.SOURCE;
-    for (AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
-      for (MdSecType mdSecType : amdSecType.getSourceMD()) {
-        MdRef mdRef = mdSecType.getMdRef();
-
-        processMdRef(mdRef, metadataType, ip, representation, basePath);
-      }
-    }
-  }
-
-  protected void processRightsMetadata(MetsWrapper metsWrapper, IPInterface ip, IPRepresentation representation,
-                                       Path basePath) throws IPException {
-    String metadataType = IPConstants.RIGHTS;
-    for (AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
-      for (MdSecType mdSecType : amdSecType.getRightsMD()) {
-        MdRef mdRef = mdSecType.getMdRef();
+    final String metadataType = IPConstants.SOURCE;
+    for (final AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
+      for (final MdSecType mdSecType : amdSecType.getSourceMD()) {
+        final MdRef mdRef = mdSecType.getMdRef();
 
         processMdRef(mdRef, metadataType, ip, representation, basePath);
       }
     }
   }
 
-  private void processMdRef(MdRef mdRef, String metadataType, IPInterface ip, IPRepresentation representation,
-                            Path basePath) throws IPException {
+  protected void processRightsMetadata(final MetsWrapper metsWrapper, final IPInterface ip,
+                                       final IPRepresentation representation, final Path basePath) throws IPException {
+    final String metadataType = IPConstants.RIGHTS;
+    for (final AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
+      for (final MdSecType mdSecType : amdSecType.getRightsMD()) {
+        final MdRef mdRef = mdSecType.getMdRef();
+
+        processMdRef(mdRef, metadataType, ip, representation, basePath);
+      }
+    }
+  }
+
+  private void processMdRef(final MdRef mdRef, final String metadataType, final IPInterface ip,
+                            final IPRepresentation representation, final Path basePath) throws IPException {
     if (mdRef != null) {
-      String href = Utils.extractedRelativePathFromHref(mdRef);
-      Path filePath = basePath.resolve(href);
+      final String href = Utils.extractedRelativePathFromHref(mdRef);
+      final Path filePath = basePath.resolve(href);
       if (Files.exists(filePath)) {
-        List<String> fileRelativeFolders = Utils
+        final List<String> fileRelativeFolders = Utils
             .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
 
-        Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef, fileRelativeFolders);
+        final Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef, fileRelativeFolders);
         if (metadataFile.isPresent()) {
           ValidationUtils.addInfo(ip.getValidationReport(),
               ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(),
               filePath);
-          IPMetadata ipMetadata = new IPMetadata(metadataFile.get());
+          final IPMetadata ipMetadata = new IPMetadata(metadataFile.get());
           ipMetadata.setCreateDate(mdRef.getCREATED());
           ipMetadata.setMetadataType(MetadataType.MetadataTypeEnum.valueOf(mdRef.getMDTYPE()));
           ipMetadata.setId(mdRef.getID());
@@ -970,8 +1033,8 @@ public class EARKUtils {
     }
   }
 
-  private void addMetadata(IPInterface ip, IPRepresentation representation, IPMetadata metadata, String metadataType)
-      throws IPException {
+  private void addMetadata(final IPInterface ip, final IPRepresentation representation, final IPMetadata metadata,
+                           final String metadataType) throws IPException {
     if (representation == null) {
       switch (metadataType) {
         case IPConstants.PRESERVATION:
@@ -990,7 +1053,7 @@ public class EARKUtils {
           ip.addOtherMetadata(metadata);
           break;
         default:
-          throw new IPException("Unknown metadata type: " + metadataType);
+          throw new IPException(UNKNOWN_METADATA_TYPE_PREFIX + metadataType);
       }
     } else {
       switch (metadataType) {
@@ -1010,31 +1073,33 @@ public class EARKUtils {
           representation.addOtherMetadata(metadata);
           break;
         default:
-          throw new IPException("Unknown metadata type: " + metadataType);
+          throw new IPException(UNKNOWN_METADATA_TYPE_PREFIX + metadataType);
       }
     }
   }
 
-  protected void processMetadata(IPInterface ip, Logger logger, IPRepresentation representation, DivType div,
-                                 String metadataType, Path basePath) throws IPException {
+  protected void processMetadata(final IPInterface ip, final Logger logger, final IPRepresentation representation,
+                                 final DivType div, final String metadataType, final Path basePath) throws IPException {
     if (div != null) {
-      List<Object> objects = null;
+      final List<Object> objects;
       if (IPConstants.DESCRIPTIVE.equals(metadataType) || IPConstants.OTHER.equals(metadataType)) {
         objects = div.getDMDID();
       } else if (IPConstants.PRESERVATION.equals(metadataType) || IPConstants.RIGHTS.equals(metadataType)
           || IPConstants.TECHNICAL.equals(metadataType) || IPConstants.SOURCE.equals(metadataType)) {
         objects = div.getADMID();
+      } else {
+        objects = null;
       }
 
       if (objects != null) {
-        for (Object obj : objects) {
+        for (final Object obj : objects) {
           if (obj instanceof MdSecType mdSecType) {
-            MdRef mdRef = mdSecType.getMdRef();
+            final MdRef mdRef = mdSecType.getMdRef();
             if (mdRef != null) {
-              String href = Utils.extractedRelativePathFromHref(mdRef);
-              Path filePath = basePath.resolve(href);
+              final String href = Utils.extractedRelativePathFromHref(mdRef);
+              final Path filePath = basePath.resolve(href);
               if (Files.exists(filePath)) {
-                List<String> fileRelativeFolders = Utils
+                final List<String> fileRelativeFolders = Utils
                     .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
 
                 processMetadataFile(ip, logger, representation, metadataType, mdRef, filePath, fileRelativeFolders);
@@ -1050,32 +1115,33 @@ public class EARKUtils {
     }
   }
 
-  protected void processMetadataFile(IPInterface ip, Logger logger, IPRepresentation representation,
-                                     String metadataType, MdRef mdRef, Path filePath, List<String> fileRelativeFolders) throws IPException {
-    Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef, fileRelativeFolders);
+  protected void processMetadataFile(final IPInterface ip, final Logger logger, final IPRepresentation representation,
+                                     final String metadataType, final MdRef mdRef, final Path filePath,
+                                     final List<String> fileRelativeFolders) throws IPException {
+    final Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef, fileRelativeFolders);
     if (metadataFile.isPresent()) {
       ValidationUtils.addInfo(ip.getValidationReport(),
           ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(), filePath);
 
       if (IPConstants.DESCRIPTIVE.equalsIgnoreCase(metadataType)) {
-        MetadataType dmdType = new MetadataType(mdRef.getMDTYPE().toUpperCase());
+        final MetadataType dmdType = new MetadataType(mdRef.getMDTYPE().toUpperCase());
         String dmdVersion = null;
         try {
           dmdVersion = mdRef.getMDTYPEVERSION();
           if (StringUtils.isNotBlank(mdRef.getOTHERMDTYPE())) {
             dmdType.setOtherType(mdRef.getOTHERMDTYPE());
           }
-          logger.debug("Metadata type valid: {}", dmdType);
-        } catch (NullPointerException | IllegalArgumentException e) {
+          logger.debug(METADATA_TYPE_VALID_MSG, dmdType);
+        } catch (final NullPointerException | IllegalArgumentException e) {
           // do nothing and use already defined values for metadataType &
           // metadataVersion
-          logger.debug("Setting metadata type to {}", dmdType);
+          logger.debug(SETTING_METADATA_TYPE_MSG, dmdType);
           ValidationUtils.addEntry(ip.getValidationReport(), ValidationConstants.UNKNOWN_DESCRIPTIVE_METADATA_TYPE,
-              ValidationEntry.LEVEL.WARN, "Setting metadata type to " + dmdType, ip.getBasePath(), filePath);
+              ValidationEntry.LEVEL.WARN, SETTING_METADATA_TYPE_PREFIX + dmdType, ip.getBasePath(), filePath);
         }
 
-        IPDescriptiveMetadata descriptiveMetadata = new IPDescriptiveMetadata(mdRef.getID(), metadataFile.get(),
-            dmdType, dmdVersion);
+        final IPDescriptiveMetadata descriptiveMetadata = new IPDescriptiveMetadata(mdRef.getID(),
+            metadataFile.get(), dmdType, dmdVersion);
         descriptiveMetadata.setCreateDate(mdRef.getCREATED());
         if (representation == null) {
           ip.addDescriptiveMetadata(descriptiveMetadata);
@@ -1083,7 +1149,7 @@ public class EARKUtils {
           representation.addDescriptiveMetadata(descriptiveMetadata);
         }
       } else if (IPConstants.PRESERVATION.equalsIgnoreCase(metadataType)) {
-        IPMetadata preservationMetadata = new IPMetadata(metadataFile.get());
+        final IPMetadata preservationMetadata = new IPMetadata(metadataFile.get());
         preservationMetadata.setCreateDate(mdRef.getCREATED());
         preservationMetadata.setMetadataType(MetadataType.MetadataTypeEnum.valueOf(mdRef.getMDTYPE()));
         preservationMetadata.setId(mdRef.getID());
@@ -1093,7 +1159,7 @@ public class EARKUtils {
           representation.addPreservationMetadata(preservationMetadata);
         }
       } else if (IPConstants.RIGHTS.equalsIgnoreCase(metadataType)) {
-        IPMetadata rightsMetadata = new IPMetadata(metadataFile.get());
+        final IPMetadata rightsMetadata = new IPMetadata(metadataFile.get());
         rightsMetadata.setCreateDate(mdRef.getCREATED());
         rightsMetadata.setMetadataType(MetadataType.MetadataTypeEnum.valueOf(mdRef.getMDTYPE()));
         rightsMetadata.setId(mdRef.getID());
@@ -1103,7 +1169,7 @@ public class EARKUtils {
           representation.addRightsMetadata(rightsMetadata);
         }
       } else if (IPConstants.OTHER.equalsIgnoreCase(metadataType)) {
-        IPMetadata otherMetadata = new IPMetadata(metadataFile.get());
+        final IPMetadata otherMetadata = new IPMetadata(metadataFile.get());
         otherMetadata.setCreateDate(mdRef.getCREATED());
         if (representation == null) {
           ip.addOtherMetadata(otherMetadata);
@@ -1114,32 +1180,34 @@ public class EARKUtils {
     }
   }
 
-  protected Optional<IPFileInterface> validateFile(IPInterface ip, Path filePath, FileType fileType,
-                                                   List<String> fileRelativeFolders) {
+  protected Optional<IPFileInterface> validateFile(final IPInterface ip, final Path filePath, final FileType fileType,
+                                                   final List<String> fileRelativeFolders) {
     return Utils.validateFile(ip, filePath, fileRelativeFolders, fileType.getCHECKSUM(), fileType.getCHECKSUMTYPE(),
         fileType.getID());
   }
 
-  protected Optional<IPFileInterface> validateMetadataFile(IPInterface ip, Path filePath, MdRef mdRef,
-                                                           List<String> fileRelativeFolders) {
+  protected Optional<IPFileInterface> validateMetadataFile(final IPInterface ip, final Path filePath,
+                                                           final MdRef mdRef, final List<String> fileRelativeFolders) {
     return Utils.validateFile(ip, filePath, fileRelativeFolders, mdRef.getCHECKSUM(), mdRef.getCHECKSUMTYPE(),
         mdRef.getID());
   }
 
-  protected IPInterface processFile(IPInterface ip, DivType div, String folder, Path basePath) {
+  protected IPInterface processFile(final IPInterface ip, final DivType div, final String folder,
+                                    final Path basePath) {
     if (div != null && div.getFptr() != null) {
-      for (Fptr fptr : div.getFptr()) {
-        Object object = fptr.getFILEID();
+      for (final Fptr fptr : div.getFptr()) {
+        final Object object = fptr.getFILEID();
         if (object instanceof FileGrpType fileGrp) {
-          for (FileType fileType : fileGrp.getFile()) {
+          for (final FileType fileType : fileGrp.getFile()) {
             if (fileType.getFLocat() != null) {
-              FLocat fLocat = fileType.getFLocat().get(0);
-              String href = Utils.extractedRelativePathFromHref(fLocat.getHref());
-              Path filePath = basePath.resolve(href);
+              final FLocat fLocat = fileType.getFLocat().get(0);
+              final String href = Utils.extractedRelativePathFromHref(fLocat.getHref());
+              final Path filePath = basePath.resolve(href);
 
               if (Files.exists(filePath)) {
-                List<String> fileRelativeFolders = Utils.getFileRelativeFolders(basePath.resolve(folder), filePath);
-                Optional<IPFileInterface> file = validateFile(ip, filePath, fileType, fileRelativeFolders);
+                final List<String> fileRelativeFolders = Utils.getFileRelativeFolders(basePath.resolve(folder),
+                    filePath);
+                final Optional<IPFileInterface> file = validateFile(ip, filePath, fileType, fileRelativeFolders);
 
                 if (file.isPresent()) {
                   if (IPConstants.SCHEMAS.equalsIgnoreCase(folder)) {
@@ -1148,7 +1216,8 @@ public class EARKUtils {
                     ip.addSchema(file.get());
                   } else if (IPConstants.DOCUMENTATION.equalsIgnoreCase(folder)) {
                     ValidationUtils.addInfo(ip.getValidationReport(),
-                        ValidationConstants.DOCUMENTATION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(), filePath);
+                        ValidationConstants.DOCUMENTATION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(),
+                        filePath);
                     ip.addDocumentation(file.get());
                   } else if (IPConstants.SUBMISSION.equalsIgnoreCase(folder) && ip instanceof AIP aip) {
                     ValidationUtils.addInfo(ip.getValidationReport(),
@@ -1177,30 +1246,32 @@ public class EARKUtils {
     return ip;
   }
 
-  protected void processRepresentationAgents(MetsWrapper representationMetsWrapper, IPRepresentation representation) {
+  protected void processRepresentationAgents(final MetsWrapper representationMetsWrapper,
+                                             final IPRepresentation representation) {
     addAgentsToMETS(representationMetsWrapper.getMets(), null, representation);
   }
 
-  protected void processRepresentationFiles(IPInterface ip, MetsWrapper representationMetsWrapper,
-                                            IPRepresentation representation, Path representationBasePath) throws IPException {
+  protected void processRepresentationFiles(final IPInterface ip, final MetsWrapper representationMetsWrapper,
+                                            final IPRepresentation representation, final Path representationBasePath)
+      throws IPException {
 
     if (representationMetsWrapper.getDataDiv() != null && representationMetsWrapper.getDataDiv().getFptr() != null) {
-      for (Fptr fptr : representationMetsWrapper.getDataDiv().getFptr()) {
-        Object object = fptr.getFILEID();
+      for (final Fptr fptr : representationMetsWrapper.getDataDiv().getFptr()) {
+        final Object object = fptr.getFILEID();
         if (object instanceof FileGrpType fileGrp) {
-          for (FileType fileType : fileGrp.getFile()) {
+          for (final FileType fileType : fileGrp.getFile()) {
             if (fileType != null && fileType.getFLocat() != null) {
-              FLocat fLocat = fileType.getFLocat().get(0);
-              String href = Utils.extractedRelativePathFromHref(fLocat.getHref());
-              Path filePath = representationBasePath.resolve(href);
+              final FLocat fLocat = fileType.getFLocat().get(0);
+              final String href = Utils.extractedRelativePathFromHref(fLocat.getHref());
+              final Path filePath = representationBasePath.resolve(href);
 
               // Verify that when protocol is file:/// the file is inside the SIP or not
               if (filePath.startsWith(representationBasePath)) {
                 // treat as a SIP (generic behaviour)
                 if (Files.exists(filePath)) {
-                  List<String> fileRelativeFolders = Utils
+                  final List<String> fileRelativeFolders = Utils
                       .getFileRelativeFolders(representationBasePath.resolve(IPConstants.DATA), filePath);
-                  Optional<IPFileInterface> file = validateFile(ip, filePath, fileType, fileRelativeFolders);
+                  final Optional<IPFileInterface> file = validateFile(ip, filePath, fileType, fileRelativeFolders);
 
                   if (file.isPresent()) {
                     representation.addFile(file.get());
@@ -1210,13 +1281,13 @@ public class EARKUtils {
                   }
                 } else {
                   // treat as a SIP shallow
-                  Optional<IPFileInterface> ipFileInterface = validateFileShallow(ip, fLocat, filePath, fileType,
+                  final Optional<IPFileInterface> ipFileInterface = validateFileShallow(ip, fLocat, filePath, fileType,
                       Collections.emptyList());
                   ipFileInterface.ifPresent(representation::addFile);
                 }
               } else {
                 // treat as a SIP shallow
-                Optional<IPFileInterface> ipFileInterface = validateFileShallow(ip, fLocat, filePath, fileType,
+                final Optional<IPFileInterface> ipFileInterface = validateFileShallow(ip, fLocat, filePath, fileType,
                     Collections.emptyList());
                 ipFileInterface.ifPresent(representation::addFile);
               }
@@ -1228,7 +1299,7 @@ public class EARKUtils {
         }
       }
 
-      for (DivType subDiv : representationMetsWrapper.getDataDiv().getDiv()) {
+      for (final DivType subDiv : representationMetsWrapper.getDataDiv().getDiv()) {
         final List<String> subDivRelativePath = new ArrayList<>();
         subDivRelativePath.add(subDiv.getLABEL());
         processRepresentationFilesSubDivs(ip, representationMetsWrapper, representation, representationBasePath, subDiv,
@@ -1244,13 +1315,14 @@ public class EARKUtils {
     }
   }
 
-  protected void processRepresentationFilesSubDivs(IPInterface ip, MetsWrapper representationMetsWrapper,
-                                                   IPRepresentation representation, Path representationBasePath, DivType div, List<String> relativePath)
-      throws IPException {
+  protected void processRepresentationFilesSubDivs(final IPInterface ip, final MetsWrapper representationMetsWrapper,
+                                                   final IPRepresentation representation,
+                                                   final Path representationBasePath, final DivType div,
+                                                   final List<String> relativePath) throws IPException {
 
     final List<Fptr> fptrs = div.getFptr();
     if (fptrs != null && !fptrs.isEmpty()) {
-      for (Fptr fptr : fptrs) {
+      for (final Fptr fptr : fptrs) {
         final Object object = fptr.getFILEID();
         if (object instanceof FileGrpType fileGrp) {
           for (FileType fileType : fileGrp.getFile()) {
@@ -1298,7 +1370,7 @@ public class EARKUtils {
       representation.addFile(IPFileShallow.createEmptyFolder(relativePath));
     }
 
-    for (DivType subDiv : div.getDiv()) {
+    for (final DivType subDiv : div.getDiv()) {
       final List<String> subDivRelativePath = new ArrayList<>(relativePath);
       subDivRelativePath.add(subDiv.getLABEL());
       processRepresentationFilesSubDivs(ip, representationMetsWrapper, representation, representationBasePath, subDiv,
@@ -1307,30 +1379,34 @@ public class EARKUtils {
 
   }
 
-  private Optional<IPFileInterface> validateFileShallow(IPInterface ip, FLocat fLocat, Path filePath, FileType fileType,
-                                                        List<String> relativeFolders) {
-    Optional<IPFileInterface> file = Optional.empty();
+  private Optional<IPFileInterface> validateFileShallow(final IPInterface ip, final FLocat fLocat,
+                                                        final Path filePath, final FileType fileType,
+                                                        final List<String> relativeFolders) {
+    final Optional<IPFileInterface> file;
 
     if (URI.create(fLocat.getHref()).getScheme() != null) {
       file = Optional.of(new IPFileShallow(URI.create(fLocat.getHref()), fileType, relativeFolders));
     } else {
       ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.REPRESENTATION_SCHEME_NOT_FOUND,
           ValidationEntry.LEVEL.ERROR, ip.getBasePath(), filePath);
+      file = Optional.empty();
     }
 
     return file;
   }
 
-  protected IPInterface processSchemasMetadata(MetsWrapper metsWrapper, IPInterface ip, Path basePath) {
+  protected IPInterface processSchemasMetadata(final MetsWrapper metsWrapper, final IPInterface ip,
+                                               final Path basePath) {
     return processFile(ip, metsWrapper.getSchemasDiv(), IPConstants.SCHEMAS, basePath);
   }
 
-  protected IPInterface processDocumentationMetadata(MetsWrapper metsWrapper, IPInterface ip, Path basePath) {
+  protected IPInterface processDocumentationMetadata(final MetsWrapper metsWrapper, final IPInterface ip,
+                                                     final Path basePath) {
     return processFile(ip, metsWrapper.getDocumentationDiv(), IPConstants.DOCUMENTATION, basePath);
   }
 
-  protected IPInterface processAncestors(MetsWrapper metsWrapper, IPInterface ip) {
-    Mets mets = metsWrapper.getMets();
+  protected IPInterface processAncestors(final MetsWrapper metsWrapper, final IPInterface ip) {
+    final Mets mets = metsWrapper.getMets();
 
     if (mets.getStructMap() != null && !mets.getStructMap().isEmpty()) {
       ip.setAncestors(metsGenerator.extractAncestorsFromStructMap(mets));

--- a/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
@@ -2,11 +2,13 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
- *
+ * <p>
  * https://github.com/keeps/commons-ip
  */
+
 package org.roda_project.commons_ip2.model.impl.eark;
 
+import jakarta.xml.bind.JAXBException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -17,9 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import javax.xml.namespace.QName;
 import org.apache.commons.lang3.StringUtils;
 import org.roda_project.commons_ip.model.ParseException;
 import org.roda_project.commons_ip.utils.IPEnums;
@@ -64,20 +64,18 @@ import org.roda_project.commons_ip2.utils.ZIPUtils;
 import org.slf4j.Logger;
 import org.xml.sax.SAXException;
 
-import jakarta.xml.bind.JAXBException;
-
-import javax.xml.namespace.QName;
-
 public class EARKUtils {
 
-  private EARKMETSCreator metsGenerator;
+  private final EARKMETSCreator metsGenerator;
+  private static final String OTHER = "OTHER";
 
   public EARKUtils(EARKMETSCreator metsGenerator) {
     this.metsGenerator = metsGenerator;
   }
 
   protected void addDescriptiveMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-    List<IPDescriptiveMetadata> descriptiveMetadata, String representationId) throws IPException, InterruptedException {
+                                                    List<IPDescriptiveMetadata> descriptiveMetadata, String representationId)
+      throws IPException, InterruptedException {
     if (descriptiveMetadata != null && !descriptiveMetadata.isEmpty()) {
       for (IPDescriptiveMetadata dm : descriptiveMetadata) {
         if (Thread.interrupted()) {
@@ -86,12 +84,12 @@ public class EARKUtils {
         IPFileInterface file = dm.getMetadata();
 
         String descriptiveFilePath = IPConstants.DESCRIPTIVE_FOLDER
-          + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
+            + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
         MdRef mdRef = metsGenerator.addDescriptiveMetadataToMETS(metsWrapper, dm, descriptiveFilePath);
 
         if (representationId != null) {
           descriptiveFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + descriptiveFilePath;
+              + descriptiveFilePath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), descriptiveFilePath, mdRef);
       }
@@ -99,7 +97,7 @@ public class EARKUtils {
   }
 
   protected void addPreservationMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-    List<IPMetadata> preservationMetadata, String representationId) throws IPException, InterruptedException {
+                                                     List<IPMetadata> preservationMetadata, String representationId) throws IPException, InterruptedException {
     if (preservationMetadata != null && !preservationMetadata.isEmpty()) {
       for (IPMetadata pm : preservationMetadata) {
         if (Thread.interrupted()) {
@@ -108,12 +106,12 @@ public class EARKUtils {
         IPFileInterface file = pm.getMetadata();
 
         String preservationMetadataPath = IPConstants.PRESERVATION_FOLDER
-          + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
+            + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
         MdRef mdRef = metsGenerator.addPreservationMetadataToMETS(metsWrapper, pm, preservationMetadataPath);
 
         if (representationId != null) {
           preservationMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId
-            + IPConstants.ZIP_PATH_SEPARATOR + preservationMetadataPath;
+              + IPConstants.ZIP_PATH_SEPARATOR + preservationMetadataPath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), preservationMetadataPath, mdRef);
       }
@@ -121,7 +119,7 @@ public class EARKUtils {
   }
 
   protected void addOtherMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-    List<IPMetadata> otherMetadata, String representationId) throws IPException, InterruptedException {
+                                              List<IPMetadata> otherMetadata, String representationId) throws IPException, InterruptedException {
     if (otherMetadata != null && !otherMetadata.isEmpty()) {
       for (IPMetadata om : otherMetadata) {
         if (Thread.interrupted()) {
@@ -130,12 +128,12 @@ public class EARKUtils {
         IPFileInterface file = om.getMetadata();
 
         String otherMetadataPath = IPConstants.OTHER_FOLDER + ModelUtils.getFoldersFromList(file.getRelativeFolders())
-          + file.getFileName();
+            + file.getFileName();
         MdRef mdRef = metsGenerator.addOtherMetadataToMETS(metsWrapper, om, otherMetadataPath);
 
         if (representationId != null) {
           otherMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + otherMetadataPath;
+              + otherMetadataPath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), otherMetadataPath, mdRef);
       }
@@ -143,7 +141,7 @@ public class EARKUtils {
   }
 
   protected void addTechnicalMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-    List<IPMetadata> technicalMetadata, String representationId) throws IPException, InterruptedException {
+                                                  List<IPMetadata> technicalMetadata, String representationId) throws IPException, InterruptedException {
     if (technicalMetadata != null && !technicalMetadata.isEmpty()) {
       for (IPMetadata tm : technicalMetadata) {
         if (Thread.interrupted()) {
@@ -152,12 +150,12 @@ public class EARKUtils {
         IPFileInterface file = tm.getMetadata();
 
         String technicalMetadataPath = IPConstants.TECHNICAL_FOLDER
-          + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
+            + ModelUtils.getFoldersFromList(file.getRelativeFolders()) + file.getFileName();
         MdRef mdRef = metsGenerator.addTechnicalMetadataToMETS(metsWrapper, tm, technicalMetadataPath);
 
         if (representationId != null) {
           technicalMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + technicalMetadataPath;
+              + technicalMetadataPath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), technicalMetadataPath, mdRef);
       }
@@ -165,7 +163,7 @@ public class EARKUtils {
   }
 
   protected void addSourceMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-    List<IPMetadata> sourceMetadata, String representationId) throws IPException, InterruptedException {
+                                               List<IPMetadata> sourceMetadata, String representationId) throws IPException, InterruptedException {
     if (sourceMetadata != null && !sourceMetadata.isEmpty()) {
       for (IPMetadata sm : sourceMetadata) {
         if (Thread.interrupted()) {
@@ -174,12 +172,12 @@ public class EARKUtils {
         IPFileInterface file = sm.getMetadata();
 
         String sourceMetadataPath = IPConstants.SOURCE_FOLDER + ModelUtils.getFoldersFromList(file.getRelativeFolders())
-          + file.getFileName();
+            + file.getFileName();
         MdRef mdRef = metsGenerator.addSourceMetadataToMETS(metsWrapper, sm, sourceMetadataPath);
 
         if (representationId != null) {
           sourceMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + sourceMetadataPath;
+              + sourceMetadataPath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), sourceMetadataPath, mdRef);
       }
@@ -187,7 +185,7 @@ public class EARKUtils {
   }
 
   protected void addRightsMetadataToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-    List<IPMetadata> rightsMetadata, String representationId) throws IPException, InterruptedException {
+                                               List<IPMetadata> rightsMetadata, String representationId) throws IPException, InterruptedException {
     if (rightsMetadata != null && !rightsMetadata.isEmpty()) {
       for (IPMetadata rm : rightsMetadata) {
         if (Thread.interrupted()) {
@@ -196,12 +194,12 @@ public class EARKUtils {
         IPFileInterface file = rm.getMetadata();
 
         String rightsMetadataPath = IPConstants.RIGHTS_FOLDER + ModelUtils.getFoldersFromList(file.getRelativeFolders())
-          + file.getFileName();
+            + file.getFileName();
         MdRef mdRef = metsGenerator.addRightsMetadataToMETS(metsWrapper, rm, rightsMetadataPath);
 
         if (representationId != null) {
           rightsMetadataPath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + rightsMetadataPath;
+              + rightsMetadataPath;
         }
         ZIPUtils.addMdRefFileToZip(zipEntries, file.getPath(), rightsMetadataPath, mdRef);
       }
@@ -209,8 +207,8 @@ public class EARKUtils {
   }
 
   protected void addRepresentationsToZipAndMETS(IPInterface ip, List<IPRepresentation> representations,
-    Map<String, ZipEntryInfo> zipEntries, MetsWrapper mainMETSWrapper, Path buildDir, IPEnums.SipType sipType)
-    throws IPException, InterruptedException {
+                                                Map<String, ZipEntryInfo> zipEntries, MetsWrapper mainMETSWrapper, Path buildDir, IPEnums.SipType sipType)
+      throws IPException, InterruptedException {
     // representations
     if (representations != null && !representations.isEmpty()) {
       if (ip instanceof SIP) {
@@ -223,44 +221,42 @@ public class EARKUtils {
         String representationId = representation.getObjectID();
         // 20160407 hsilva: not being used by Common Specification v0.13
         final boolean isRepresentationMetadataOther = (representation.getOtherMetadata() != null
-          && !representation.getOtherMetadata().isEmpty());
+            && !representation.getOtherMetadata().isEmpty());
         final boolean isRepresentationMetadata = ((representation.getDescriptiveMetadata() != null
-          && !representation.getDescriptiveMetadata().isEmpty())
-          || (representation.getPreservationMetadata() != null && !representation.getPreservationMetadata().isEmpty()));
+            && !representation.getDescriptiveMetadata().isEmpty())
+            || (representation.getPreservationMetadata() != null && !representation.getPreservationMetadata().isEmpty()));
         final boolean isRepresentationDocumentation = (representation.getDocumentation() != null
-          && !representation.getDocumentation().isEmpty());
+            && !representation.getDocumentation().isEmpty());
         final boolean isRepresentationSchemas = (representation.getSchemas() != null
-          && !representation.getSchemas().isEmpty());
+            && !representation.getSchemas().isEmpty());
         final boolean isRepresentationsData = (representation.getData() != null && !representation.getData().isEmpty());
         final IPHeader header = new IPHeader(IPEnums.IPStatus.NEW).setAgents(representation.getAgents());
         final MetsWrapper representationMETSWrapper;
 
         if (IPEnums.SipType.ERMS.equals(sipType)) {
           representationMETSWrapper = metsGenerator.generateMETS(representationId, representation.getDescription(),
-            ip.getProfile(), false, Optional.empty(), null, header,
-            mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(), representation.getContentType(),
-            representation.getContentInformationType(), isRepresentationMetadata, isRepresentationMetadataOther,
-            isRepresentationSchemas, isRepresentationDocumentation, false, false, isRepresentationsData);
+              ip.getProfile(), false, Optional.empty(), null, header,
+              mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(), representation.getContentType(),
+              representation.getContentInformationType(), isRepresentationMetadata, isRepresentationMetadataOther,
+              isRepresentationSchemas, isRepresentationDocumentation, false, false, isRepresentationsData);
         } else if (IPEnums.SipType.SIARD.equals(sipType)) {
           representation.setContentInformationType(representation.getContentInformationType());
           representationMETSWrapper = metsGenerator.generateMetsSiard(representationId, representation.getDescription(),
-            "https://citssiard.dilcis.eu/profile/E-ARK-SIARD-REPRESENTATION.xml", false, Optional.empty(), null, header,
-            mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(), representation.getContentType(),
-            representation.getContentInformationType(), isRepresentationMetadata, isRepresentationMetadataOther,
-            isRepresentationSchemas, isRepresentationDocumentation, false, false, isRepresentationsData);
-        }
-
-        else if (!IPEnums.SipType.EARK2S.equals(sipType)) {
+              "https://citssiard.dilcis.eu/profile/E-ARK-SIARD-REPRESENTATION.xml", false, Optional.empty(), null, header,
+              mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(), representation.getContentType(),
+              representation.getContentInformationType(), isRepresentationMetadata, isRepresentationMetadataOther,
+              isRepresentationSchemas, isRepresentationDocumentation, false, false, isRepresentationsData);
+        } else if (!IPEnums.SipType.EARK2S.equals(sipType)) {
           representationMETSWrapper = metsGenerator.generateMETS(representationId, representation.getDescription(),
-            ip.getProfile(), false, Optional.empty(), null, header,
-            mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(), representation.getContentType(),
-            representation.getContentInformationType(), isRepresentationMetadata, isRepresentationMetadataOther,
-            isRepresentationSchemas, isRepresentationDocumentation, false, false, isRepresentationsData);
+              ip.getProfile(), false, Optional.empty(), null, header,
+              mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(), representation.getContentType(),
+              representation.getContentInformationType(), isRepresentationMetadata, isRepresentationMetadataOther,
+              isRepresentationSchemas, isRepresentationDocumentation, false, false, isRepresentationsData);
         } else {
           representationMETSWrapper = metsGenerator.generateMetsShallow(representation, ip.getProfile(), false,
-            Optional.empty(), null, header, mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(),
-            isRepresentationMetadata, isRepresentationMetadataOther, isRepresentationSchemas,
-            isRepresentationDocumentation, false, false, isRepresentationsData);
+              Optional.empty(), null, header, mainMETSWrapper.getMets().getMetsHdr().getOAISPACKAGETYPE(),
+              isRepresentationMetadata, isRepresentationMetadataOther, isRepresentationSchemas,
+              isRepresentationDocumentation, false, false, isRepresentationsData);
         }
 
         representationMETSWrapper.getMainDiv().setTYPE(representation.getStatus().asString());
@@ -268,65 +264,65 @@ public class EARKUtils {
         // representation data
         if (IPEnums.SipType.ERMS.equals(sipType)) {
           addRepresentationDataFilesToZipErmsAndMETS(ip, zipEntries, representationMETSWrapper, representation,
-            representationId);
+              representationId);
         } else if (IPEnums.SipType.SIARD.equals(sipType)) {
           addRepresentationDataFilesToZipSiardAndMETS(ip, zipEntries, representationMETSWrapper, representation,
-            representationId);
+              representationId);
         } else {
           addRepresentationDataFilesToZipAndMETS(ip, zipEntries, representationMETSWrapper, representation,
-            representationId);
+              representationId);
         }
 
         // representation descriptive metadata
         addDescriptiveMetadataToZipAndMETS(zipEntries, representationMETSWrapper,
-          representation.getDescriptiveMetadata(), representationId);
+            representation.getDescriptiveMetadata(), representationId);
 
         // representation preservation metadata
         addPreservationMetadataToZipAndMETS(zipEntries, representationMETSWrapper,
-          representation.getPreservationMetadata(), representationId);
+            representation.getPreservationMetadata(), representationId);
 
         // representation technical metadata
         addTechnicalMetadataToZipAndMETS(zipEntries, representationMETSWrapper, representation.getTechnicalMetadata(),
-          representationId);
+            representationId);
 
         // representation source metadata
         addSourceMetadataToZipAndMETS(zipEntries, representationMETSWrapper,
-          representation.getSourceMetadata(), representationId);
-          
+            representation.getSourceMetadata(), representationId);
+
         // representation rights metadata
         addRightsMetadataToZipAndMETS(zipEntries, representationMETSWrapper,
-          representation.getRightsMetadata(), representationId);
+            representation.getRightsMetadata(), representationId);
 
         // representation other metadata
         addOtherMetadataToZipAndMETS(zipEntries, representationMETSWrapper, representation.getOtherMetadata(),
-          representationId);
+            representationId);
 
         // representation schemas
         addSchemasToZipAndMETS(zipEntries, representationMETSWrapper, representation.getSchemas(), representationId);
 
         // representation documentation
         addDocumentationToZipAndMETS(zipEntries, representationMETSWrapper, representation.getDocumentation(),
-          representationId);
+            representationId);
 
         // add representation METS to Zip file and to main METS file
         if (IPEnums.SipType.ERMS.equals(sipType)) {
           metsGenerator.addRepresentationMETSToZipAndToMainMETS(zipEntries, mainMETSWrapper, representationId,
-            representationMETSWrapper,
-            IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.DATA
-              + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.METS_FILE,
-            buildDir);
+              representationMETSWrapper,
+              IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.DATA
+                  + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.METS_FILE,
+              buildDir);
         } else if (IPEnums.SipType.SIARD.equals(sipType)) {
           metsGenerator.addRepresentationSiardMETSToZipAndToMainMETS(zipEntries, mainMETSWrapper, representationId,
-            representationMETSWrapper,
-            IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.DATA
-              + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.METS_FILE,
-            buildDir);
+              representationMETSWrapper,
+              IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.DATA
+                  + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.METS_FILE,
+              buildDir);
 
         } else {
           metsGenerator.addRepresentationMETSToZipAndToMainMETS(zipEntries, mainMETSWrapper, representationId,
-            representationMETSWrapper, IPConstants.REPRESENTATIONS_FOLDER + representationId
-              + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.METS_FILE,
-            buildDir);
+              representationMETSWrapper, IPConstants.REPRESENTATIONS_FOLDER + representationId
+                  + IPConstants.ZIP_PATH_SEPARATOR + IPConstants.METS_FILE,
+              buildDir);
         }
 
         metsGenerator.cleanFileGrpStructure();
@@ -339,8 +335,8 @@ public class EARKUtils {
   }
 
   private void addRepresentationDataFilesToZipErmsAndMETS(IPInterface ip, Map<String, ZipEntryInfo> zipEntries,
-    MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
-    throws InterruptedException, IPException {
+                                                          MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
+      throws InterruptedException, IPException {
     if (representation.getData() != null && !representation.getData().isEmpty()) {
       if (ip instanceof SIP sip) {
         sip.notifySipBuildRepresentationProcessingStarted(representation.getData().size());
@@ -357,7 +353,7 @@ public class EARKUtils {
 
           dataFilePath = IPConstants.DATA_FOLDER + dataFilePath;
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + dataFilePath;
+              + dataFilePath;
           ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
         } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
@@ -376,8 +372,8 @@ public class EARKUtils {
   }
 
   private void addRepresentationDataFilesToZipSiardAndMETS(IPInterface ip, Map<String, ZipEntryInfo> zipEntries,
-    MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
-    throws InterruptedException, IPException {
+                                                           MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
+      throws InterruptedException, IPException {
     if (representation.getData() != null && !representation.getData().isEmpty()) {
       if (ip instanceof SIP sip) {
         sip.notifySipBuildRepresentationProcessingStarted(representation.getData().size());
@@ -393,11 +389,11 @@ public class EARKUtils {
           FileType fileType = metsGenerator.addDataFileToMETS(representationMETSWrapper, dataFilePath, file.getPath());
           if (representation.getContentInformationType().getOtherType() != null) {
             fileType.getOtherAttributes().put(QName.valueOf("csip:OTHERCONTENTINFORMATIONTYPE"),
-              representation.getContentInformationType().getOtherType());
+                representation.getContentInformationType().getOtherType());
           }
           dataFilePath = IPConstants.DATA_FOLDER + dataFilePath;
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + dataFilePath;
+              + dataFilePath;
           ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
         } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
@@ -415,8 +411,8 @@ public class EARKUtils {
   }
 
   protected void addRepresentationDataFilesToZipAndMETS(IPInterface ip, Map<String, ZipEntryInfo> zipEntries,
-    MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
-    throws IPException, InterruptedException {
+                                                        MetsWrapper representationMETSWrapper, IPRepresentation representation, String representationId)
+      throws IPException, InterruptedException {
     if (representation.getData() != null && !representation.getData().isEmpty()) {
       if (ip instanceof SIP sip) {
         sip.notifySipBuildRepresentationProcessingStarted(representation.getData().size());
@@ -429,11 +425,11 @@ public class EARKUtils {
 
         if (file instanceof IPFile) {
           String dataFilePath = IPConstants.DATA_FOLDER + ModelUtils.getFoldersFromList(file.getRelativeFolders())
-            + file.getFileName();
+              + file.getFileName();
           FileType fileType = metsGenerator.addDataFileToMETS(representationMETSWrapper, dataFilePath, file.getPath());
 
           dataFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + dataFilePath;
+              + dataFilePath;
           ZIPUtils.addFileTypeFileToZip(zipEntries, file.getPath(), dataFilePath, fileType);
         } else if (file instanceof IPFileShallow shallow && (shallow.getFileLocation() != null)) {
           metsGenerator.addDataFileToMETS(representationMETSWrapper, shallow);
@@ -451,7 +447,7 @@ public class EARKUtils {
   }
 
   protected void addSchemasToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-    List<IPFileInterface> schemas, String representationId) throws IPException, InterruptedException {
+                                        List<IPFileInterface> schemas, String representationId) throws IPException, InterruptedException {
     if (schemas != null && !schemas.isEmpty()) {
       for (IPFileInterface schema : schemas) {
         if (Thread.interrupted()) {
@@ -459,12 +455,12 @@ public class EARKUtils {
         }
 
         String schemaFilePath = IPConstants.SCHEMAS_FOLDER + ModelUtils.getFoldersFromList(schema.getRelativeFolders())
-          + schema.getFileName();
+            + schema.getFileName();
         FileType fileType = metsGenerator.addSchemaFileToMETS(metsWrapper, schemaFilePath, schema.getPath());
 
         if (representationId != null) {
           schemaFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + schemaFilePath;
+              + schemaFilePath;
         }
         ZIPUtils.addFileTypeFileToZip(zipEntries, schema.getPath(), schemaFilePath, fileType);
       }
@@ -472,7 +468,7 @@ public class EARKUtils {
   }
 
   protected void addDocumentationToZipAndMETS(Map<String, ZipEntryInfo> zipEntries, MetsWrapper metsWrapper,
-    List<IPFileInterface> documentation, String representationId) throws IPException, InterruptedException {
+                                              List<IPFileInterface> documentation, String representationId) throws IPException, InterruptedException {
     if (documentation != null && !documentation.isEmpty()) {
       for (IPFileInterface doc : documentation) {
         if (Thread.interrupted()) {
@@ -480,12 +476,12 @@ public class EARKUtils {
         }
 
         String documentationFilePath = IPConstants.DOCUMENTATION_FOLDER
-          + ModelUtils.getFoldersFromList(doc.getRelativeFolders()) + doc.getFileName();
+            + ModelUtils.getFoldersFromList(doc.getRelativeFolders()) + doc.getFileName();
         FileType fileType = metsGenerator.addDocumentationFileToMETS(metsWrapper, documentationFilePath, doc.getPath());
 
         if (representationId != null) {
           documentationFilePath = IPConstants.REPRESENTATIONS_FOLDER + representationId + IPConstants.ZIP_PATH_SEPARATOR
-            + documentationFilePath;
+              + documentationFilePath;
         }
         ZIPUtils.addFileTypeFileToZip(zipEntries, doc.getPath(), documentationFilePath, fileType);
       }
@@ -493,7 +489,7 @@ public class EARKUtils {
   }
 
   protected void addDefaultSchemas(Logger logger, List<IPFileInterface> schemas, Path buildDir, Boolean override)
-    throws InterruptedException {
+      throws InterruptedException {
     try {
       if (Thread.interrupted()) {
         throw new InterruptedException();
@@ -506,9 +502,9 @@ public class EARKUtils {
 
         if (!override) {
           if (tempSchema.equals(IPConstants.SCHEMA_EARK_CSIP_FILENAME)
-            || tempSchema.equals(IPConstants.SCHEMA_EARK_SIP_FILENAME)
-            || tempSchema.equals(IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION)
-            || tempSchema.equals(IPConstants.SCHEMA_XLINK_FILENAME)) {
+              || tempSchema.equals(IPConstants.SCHEMA_EARK_SIP_FILENAME)
+              || tempSchema.equals(IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION)
+              || tempSchema.equals(IPConstants.SCHEMA_XLINK_FILENAME)) {
             schemas.remove(0);
             tempSchema = "";
           }
@@ -516,21 +512,25 @@ public class EARKUtils {
       }
 
       Path earkCsipSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
-        IPConstants.SCHEMA_EARK_CSIP_FILENAME, IPConstants.SCHEMA_EARK_CSIP_RELATIVE_PATH_FROM_RESOURCES);
-      if (!tempSchema.equals(IPConstants.SCHEMA_EARK_CSIP_FILENAME))
+          IPConstants.SCHEMA_EARK_CSIP_FILENAME, IPConstants.SCHEMA_EARK_CSIP_RELATIVE_PATH_FROM_RESOURCES);
+      if (!tempSchema.equals(IPConstants.SCHEMA_EARK_CSIP_FILENAME)) {
         schemas.add(new IPFile(earkCsipSchema, IPConstants.SCHEMA_EARK_CSIP_FILENAME));
+      }
       Path earkSipSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
-        IPConstants.SCHEMA_EARK_SIP_FILENAME, IPConstants.SCHEMA_EARK_SIP_RELATIVE_PATH_FROM_RESOURCES);
-      if (!tempSchema.equals(IPConstants.SCHEMA_EARK_SIP_FILENAME))
+          IPConstants.SCHEMA_EARK_SIP_FILENAME, IPConstants.SCHEMA_EARK_SIP_RELATIVE_PATH_FROM_RESOURCES);
+      if (!tempSchema.equals(IPConstants.SCHEMA_EARK_SIP_FILENAME)) {
         schemas.add(new IPFile(earkSipSchema, IPConstants.SCHEMA_EARK_SIP_FILENAME));
+      }
       Path metsSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
-        IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION, IPConstants.SCHEMA_METS_RELATIVE_PATH_FROM_RESOURCES);
-      if (!tempSchema.equals(IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION))
+          IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION, IPConstants.SCHEMA_METS_RELATIVE_PATH_FROM_RESOURCES);
+      if (!tempSchema.equals(IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION)) {
         schemas.add(new IPFile(metsSchema, IPConstants.SCHEMA_METS_FILENAME_WITH_VERSION));
+      }
       Path xlinkSchema = Utils.copyResourceFromClasspathToDir(EARKSIP.class, buildDir,
-        IPConstants.SCHEMA_XLINK_FILENAME, IPConstants.SCHEMA_XLINK_RELATIVE_PATH_FROM_RESOURCES);
-      if (!tempSchema.equals(IPConstants.SCHEMA_XLINK_FILENAME))
+          IPConstants.SCHEMA_XLINK_FILENAME, IPConstants.SCHEMA_XLINK_RELATIVE_PATH_FROM_RESOURCES);
+      if (!tempSchema.equals(IPConstants.SCHEMA_XLINK_FILENAME)) {
         schemas.add(new IPFile(xlinkSchema, IPConstants.SCHEMA_XLINK_FILENAME));
+      }
 
     } catch (IOException e) {
       logger.error("Error while trying to add default schemas", e);
@@ -538,16 +538,16 @@ public class EARKUtils {
   }
 
   protected void addSubmissionsToZipAndMETS(final Map<String, ZipEntryInfo> zipEntries, final MetsWrapper metsWrapper,
-    final List<IPFileInterface> submissions) throws IPException, InterruptedException {
+                                            final List<IPFileInterface> submissions) throws IPException, InterruptedException {
     if (submissions != null && !submissions.isEmpty()) {
       for (IPFileInterface submission : submissions) {
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }
         final String submissionFilePath = IPConstants.SUBMISSION_FOLDER
-          + ModelUtils.getFoldersFromList(submission.getRelativeFolders()) + submission.getFileName();
+            + ModelUtils.getFoldersFromList(submission.getRelativeFolders()) + submission.getFileName();
         final FileType fileType = metsGenerator.addSubmissionFileToMETS(metsWrapper, submissionFilePath,
-          submission.getPath());
+            submission.getPath());
         ZIPUtils.addFileTypeFileToZip(zipEntries, submission.getPath(), submissionFilePath, fileType);
       }
     }
@@ -572,11 +572,11 @@ public class EARKUtils {
       } catch (JAXBException | ParseException | SAXException | IOException e) {
         mainMets = null;
         ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.MAIN_METS_NOT_VALID,
-          ValidationEntry.LEVEL.ERROR, e, ip.getBasePath(), mainMETSFile);
+            ValidationEntry.LEVEL.ERROR, e, ip.getBasePath(), mainMETSFile);
       }
     } else {
       ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.MAIN_METS_FILE_NOT_FOUND,
-        ValidationEntry.LEVEL.ERROR, ip.getBasePath(), mainMETSFile);
+          ValidationEntry.LEVEL.ERROR, ip.getBasePath(), mainMETSFile);
     }
     return new MetsWrapper(mainMets, mainMETSFile);
   }
@@ -593,25 +593,25 @@ public class EARKUtils {
 
       if (ip instanceof SIP && IPEnums.IPType.SIP != packageType) {
         throw new ParseException(
-          "METS 'OAISPACKAGETYPE' should have the value 'SIP' but it doesn't. Instead, it has '" + packageType + "'.");
+            "METS 'OAISPACKAGETYPE' should have the value 'SIP' but it doesn't. Instead, it has '" + packageType + "'.");
       } else if (ip instanceof AIP && IPEnums.IPType.AIP != packageType) {
         throw new ParseException(
-          "METS 'OAISPACKAGETYPE' should have the value 'AIP' but it doesn't. Instead, it has '" + packageType + "'.");
+            "METS 'OAISPACKAGETYPE' should have the value 'AIP' but it doesn't. Instead, it has '" + packageType + "'.");
       }
     } catch (IllegalArgumentException e) {
       throw new ParseException("METS 'OAISPACKAGETYPE' attribute does not contain a valid package type");
     }
 
-    IPContentType ipContentType = getContentType(mets);
+    final IPContentType ipContentType = getContentType(mets);
     ip.setContentType(ipContentType);
   }
 
-  private IPContentType getContentType(Mets mets) throws ParseException {
+  private IPContentType getContentType(final Mets mets) throws ParseException {
     String contentType = mets.getTYPE();
     if (StringUtils.isBlank(contentType)) {
       throw new ParseException("METS 'TYPE' attribute does not contain any value");
     }
-    if ("OTHER".equalsIgnoreCase(contentType)) {
+    if (OTHER.equalsIgnoreCase(contentType)) {
       if (StringUtils.isBlank(mets.getOTHERTYPE())) {
         throw new ParseException("METS 'OTHERTYPE' attribute does not contain any value");
       }
@@ -620,20 +620,20 @@ public class EARKUtils {
     return new IPContentType(contentType);
   }
 
-  protected void setIPContentInformationType(Mets mets, IPInterface ip) throws ParseException {
-    IPContentInformationType ipContentInformationType = getIpContentInformationType(mets);
+  protected void setIPContentInformationType(final Mets mets, final IPInterface ip) throws ParseException {
+    final IPContentInformationType ipContentInformationType = getIpContentInformationType(mets);
     if (ipContentInformationType == null) {
       return;
     }
     ip.setContentInformationType(ipContentInformationType);
   }
 
-  private IPContentInformationType getIpContentInformationType(Mets mets) throws ParseException {
+  private IPContentInformationType getIpContentInformationType(final Mets mets) throws ParseException {
     String contentInformationType = mets.getCONTENTINFORMATIONTYPE();
     if (StringUtils.isBlank(contentInformationType)) {
       return null;
     }
-    if ("OTHER".equalsIgnoreCase(contentInformationType)) {
+    if (OTHER.equalsIgnoreCase(contentInformationType)) {
       if (StringUtils.isBlank(mets.getOTHERCONTENTINFORMATIONTYPE())) {
         throw new ParseException("METS 'OTHERCONTENTINFORMATIONTYPE' attribute does not contain any value");
       }
@@ -655,37 +655,39 @@ public class EARKUtils {
   }
 
   protected MetsWrapper processRepresentationMets(IPInterface ip, Path representationMetsFile,
-    IPRepresentation representation) {
+                                                  IPRepresentation representation) {
     Mets representationMets = null;
     if (Files.exists(representationMetsFile)) {
       ValidationUtils.addInfo(ip.getValidationReport(), ValidationConstants.REPRESENTATION_METS_FILE_FOUND,
-        ip.getBasePath(), representationMetsFile);
+          ip.getBasePath(), representationMetsFile);
       try {
         representationMets = METSUtils.instantiateMETSFromFile(representationMetsFile);
         setRepresentationContentType(representationMets, representation);
         setRepresentationContentInformationType(representationMets, representation);
         ValidationUtils.addInfo(ip.getValidationReport(), ValidationConstants.REPRESENTATION_METS_IS_VALID,
-          ip.getBasePath(), representationMetsFile);
+            ip.getBasePath(), representationMetsFile);
       } catch (JAXBException | ParseException | SAXException | IOException e) {
         representationMets = null;
         ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.REPRESENTATION_METS_NOT_VALID,
-          ValidationEntry.LEVEL.ERROR, e, ip.getBasePath(), representationMetsFile);
+            ValidationEntry.LEVEL.ERROR, e, ip.getBasePath(), representationMetsFile);
       }
     } else {
       ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.REPRESENTATION_METS_FILE_NOT_FOUND,
-        ValidationEntry.LEVEL.ERROR, ip.getBasePath(), representationMetsFile);
+          ValidationEntry.LEVEL.ERROR, ip.getBasePath(), representationMetsFile);
     }
     return new MetsWrapper(representationMets, representationMetsFile);
   }
 
 
-  protected void setRepresentationContentType(Mets mets, IPRepresentation representation) throws ParseException {
-    IPContentType ipContentType = getContentType(mets);
+  protected void setRepresentationContentType(final Mets mets, final IPRepresentation representation)
+      throws ParseException {
+    final IPContentType ipContentType = getContentType(mets);
     representation.setContentType(ipContentType);
   }
 
-  protected void setRepresentationContentInformationType(Mets mets, IPRepresentation representation) throws ParseException {
-    IPContentInformationType ipContentInformationType = getIpContentInformationType(mets);
+  protected void setRepresentationContentInformationType(final Mets mets, final IPRepresentation representation)
+      throws ParseException {
+    final IPContentInformationType ipContentInformationType = getIpContentInformationType(mets);
     if (ipContentInformationType == null) {
       return;
     }
@@ -693,18 +695,18 @@ public class EARKUtils {
   }
 
   protected IPInterface processRepresentations(MetsWrapper metsWrapper, IPInterface ip, Logger logger)
-    throws IPException {
+      throws IPException {
 
     if (metsWrapper.getMainDiv() != null && metsWrapper.getMainDiv().getDiv() != null) {
       for (DivType div : metsWrapper.getMainDiv().getDiv()) {
         if (div.getLABEL().startsWith(IPConstants.REPRESENTATIONS_WITH_FIRST_LETTER_CAPITAL)
-          && (div.getMptr() != null && !div.getMptr().isEmpty())) {
+            && (div.getMptr() != null && !div.getMptr().isEmpty())) {
           // we can assume one and only one mets for each representation div
           Mptr mptr = div.getMptr().get(0);
           String href = Utils.extractedRelativePathFromHref(mptr.getHref());
           Path metsFilePath = ip.getBasePath().resolve(href);
           IPRepresentation representation = new IPRepresentation(
-            div.getLABEL().replaceFirst(IPConstants.REPRESENTATIONS_WITH_FIRST_LETTER_CAPITAL + "/", ""));
+              div.getLABEL().replaceFirst(IPConstants.REPRESENTATIONS_WITH_FIRST_LETTER_CAPITAL + "/", ""));
           MetsWrapper representationMetsWrapper = processRepresentationMets(ip, metsFilePath, representation);
 
           if (representationMetsWrapper.getMets() != null) {
@@ -755,7 +757,7 @@ public class EARKUtils {
       // post-process validations
       if (ip.getRepresentations().isEmpty()) {
         ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.MAIN_METS_NO_REPRESENTATIONS_FOUND,
-          ValidationEntry.LEVEL.WARN, metsWrapper.getMainDiv(), ip.getBasePath(), metsWrapper.getMetsPath());
+            ValidationEntry.LEVEL.WARN, metsWrapper.getMainDiv(), ip.getBasePath(), metsWrapper.getMetsPath());
       }
     }
 
@@ -774,14 +776,14 @@ public class EARKUtils {
     }
     if (res == null) {
       ValidationUtils.addIssue(ip.getValidationReport(),
-        mainMets ? ValidationConstants.MAIN_METS_HAS_NO_E_ARK_STRUCT_MAP
-          : ValidationConstants.REPRESENTATION_METS_HAS_NO_E_ARK_STRUCT_MAP,
-        ValidationEntry.LEVEL.ERROR, res, ip.getBasePath(), metsWrapper.getMetsPath());
+          mainMets ? ValidationConstants.MAIN_METS_HAS_NO_E_ARK_STRUCT_MAP
+              : ValidationConstants.REPRESENTATION_METS_HAS_NO_E_ARK_STRUCT_MAP,
+          ValidationEntry.LEVEL.ERROR, res, ip.getBasePath(), metsWrapper.getMetsPath());
     } else {
       ValidationUtils.addInfo(ip.getValidationReport(),
-        mainMets ? ValidationConstants.MAIN_METS_HAS_E_ARK_STRUCT_MAP
-          : ValidationConstants.REPRESENTATION_METS_HAS_E_ARK_STRUCT_MAP,
-        res, ip.getBasePath(), metsWrapper.getMetsPath());
+          mainMets ? ValidationConstants.MAIN_METS_HAS_E_ARK_STRUCT_MAP
+              : ValidationConstants.REPRESENTATION_METS_HAS_E_ARK_STRUCT_MAP,
+          res, ip.getBasePath(), metsWrapper.getMetsPath());
     }
     return res;
   }
@@ -810,7 +812,7 @@ public class EARKUtils {
   }
 
   protected void processDescriptiveMetadata(MetsWrapper metsWrapper, IPInterface ip, Logger logger,
-    IPRepresentation representation, Path basePath) throws IPException {
+                                            IPRepresentation representation, Path basePath) throws IPException {
     String metadataType = IPConstants.DESCRIPTIVE;
     List<MdSecType> dmdSec = metsWrapper.getMets().getDmdSec();
     for (MdSecType mdSecType : dmdSec) {
@@ -820,13 +822,13 @@ public class EARKUtils {
         Path filePath = basePath.resolve(href);
         if (Files.exists(filePath)) {
           List<String> fileRelativeFolders = Utils
-            .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
+              .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
 
           Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef, fileRelativeFolders);
           if (metadataFile.isPresent()) {
             ValidationUtils.addInfo(ip.getValidationReport(),
-              ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(),
-              filePath);
+                ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(),
+                filePath);
 
             MetadataType dmdType = new MetadataType(mdRef.getMDTYPE().toUpperCase());
             String dmdVersion = null;
@@ -841,11 +843,11 @@ public class EARKUtils {
               // metadataVersion
               logger.debug("Setting metadata type to {}", dmdType);
               ValidationUtils.addEntry(ip.getValidationReport(), ValidationConstants.UNKNOWN_DESCRIPTIVE_METADATA_TYPE,
-                ValidationEntry.LEVEL.WARN, "Setting metadata type to " + dmdType, ip.getBasePath(), filePath);
+                  ValidationEntry.LEVEL.WARN, "Setting metadata type to " + dmdType, ip.getBasePath(), filePath);
             }
 
             IPDescriptiveMetadata descriptiveMetadata = new IPDescriptiveMetadata(mdRef.getID(), metadataFile.get(),
-              dmdType, dmdVersion);
+                dmdType, dmdVersion);
             descriptiveMetadata.setCreateDate(mdRef.getCREATED());
             if (representation == null) {
               ip.addDescriptiveMetadata(descriptiveMetadata);
@@ -855,21 +857,21 @@ public class EARKUtils {
           }
         } else {
           ValidationUtils.addIssue(ip.getValidationReport(),
-            ValidationConstants.getMetadataFileNotFoundString(metadataType), ValidationEntry.LEVEL.ERROR,
-            ip.getBasePath(), filePath);
+              ValidationConstants.getMetadataFileNotFoundString(metadataType), ValidationEntry.LEVEL.ERROR,
+              ip.getBasePath(), filePath);
         }
       }
     }
   }
 
   protected void processOtherMetadata(MetsWrapper metsWrapper, IPInterface ip, Logger logger,
-    IPRepresentation representation, Path basePath) throws IPException {
+                                      IPRepresentation representation, Path basePath) throws IPException {
 
     processMetadata(ip, logger, representation, metsWrapper.getOtherMetadataDiv(), IPConstants.OTHER, basePath);
   }
 
   protected void processPreservationMetadata(MetsWrapper metsWrapper, IPInterface ip, IPRepresentation representation,
-    Path basePath) throws IPException {
+                                             Path basePath) throws IPException {
     String metadataType = IPConstants.PRESERVATION;
     for (AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
       for (MdSecType mdSecType : amdSecType.getDigiprovMD()) {
@@ -881,7 +883,7 @@ public class EARKUtils {
   }
 
   protected void processTechnicalMetadata(MetsWrapper metsWrapper, IPInterface ip, IPRepresentation representation,
-    Path basePath) throws IPException {
+                                          Path basePath) throws IPException {
     String metadataType = IPConstants.TECHNICAL;
     for (AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
       for (MdSecType mdSecType : amdSecType.getTechMD()) {
@@ -893,7 +895,7 @@ public class EARKUtils {
   }
 
   protected void processSourceMetadata(MetsWrapper metsWrapper, IPInterface ip, IPRepresentation representation,
-    Path basePath) throws IPException {
+                                       Path basePath) throws IPException {
 
     String metadataType = IPConstants.SOURCE;
     for (AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
@@ -906,7 +908,7 @@ public class EARKUtils {
   }
 
   protected void processRightsMetadata(MetsWrapper metsWrapper, IPInterface ip, IPRepresentation representation,
-    Path basePath) throws IPException {
+                                       Path basePath) throws IPException {
     String metadataType = IPConstants.RIGHTS;
     for (AmdSecType amdSecType : metsWrapper.getMets().getAmdSec()) {
       for (MdSecType mdSecType : amdSecType.getRightsMD()) {
@@ -918,19 +920,19 @@ public class EARKUtils {
   }
 
   private void processMdRef(MdRef mdRef, String metadataType, IPInterface ip, IPRepresentation representation,
-    Path basePath) throws IPException {
+                            Path basePath) throws IPException {
     if (mdRef != null) {
       String href = Utils.extractedRelativePathFromHref(mdRef);
       Path filePath = basePath.resolve(href);
       if (Files.exists(filePath)) {
         List<String> fileRelativeFolders = Utils
-          .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
+            .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
 
         Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef, fileRelativeFolders);
         if (metadataFile.isPresent()) {
           ValidationUtils.addInfo(ip.getValidationReport(),
-            ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(),
-            filePath);
+              ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(),
+              filePath);
           IPMetadata ipMetadata = new IPMetadata(metadataFile.get());
           ipMetadata.setCreateDate(mdRef.getCREATED());
           ipMetadata.setMetadataType(MetadataType.MetadataTypeEnum.valueOf(mdRef.getMDTYPE()));
@@ -939,14 +941,14 @@ public class EARKUtils {
         }
       } else {
         ValidationUtils.addIssue(ip.getValidationReport(),
-          ValidationConstants.getMetadataFileNotFoundString(metadataType), ValidationEntry.LEVEL.ERROR,
-          ip.getBasePath(), filePath);
+            ValidationConstants.getMetadataFileNotFoundString(metadataType), ValidationEntry.LEVEL.ERROR,
+            ip.getBasePath(), filePath);
       }
     }
   }
 
   private void addMetadata(IPInterface ip, IPRepresentation representation, IPMetadata metadata, String metadataType)
-    throws IPException {
+      throws IPException {
     if (representation == null) {
       switch (metadataType) {
         case IPConstants.PRESERVATION:
@@ -991,13 +993,13 @@ public class EARKUtils {
   }
 
   protected void processMetadata(IPInterface ip, Logger logger, IPRepresentation representation, DivType div,
-    String metadataType, Path basePath) throws IPException {
+                                 String metadataType, Path basePath) throws IPException {
     if (div != null) {
       List<Object> objects = null;
       if (IPConstants.DESCRIPTIVE.equals(metadataType) || IPConstants.OTHER.equals(metadataType)) {
         objects = div.getDMDID();
       } else if (IPConstants.PRESERVATION.equals(metadataType) || IPConstants.RIGHTS.equals(metadataType)
-        || IPConstants.TECHNICAL.equals(metadataType) || IPConstants.SOURCE.equals(metadataType)) {
+          || IPConstants.TECHNICAL.equals(metadataType) || IPConstants.SOURCE.equals(metadataType)) {
         objects = div.getADMID();
       }
 
@@ -1010,13 +1012,13 @@ public class EARKUtils {
               Path filePath = basePath.resolve(href);
               if (Files.exists(filePath)) {
                 List<String> fileRelativeFolders = Utils
-                  .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
+                    .getFileRelativeFolders(basePath.resolve(IPConstants.METADATA).resolve(metadataType), filePath);
 
                 processMetadataFile(ip, logger, representation, metadataType, mdRef, filePath, fileRelativeFolders);
               } else {
                 ValidationUtils.addIssue(ip.getValidationReport(),
-                  ValidationConstants.getMetadataFileNotFoundString(metadataType), ValidationEntry.LEVEL.ERROR,
-                  ip.getBasePath(), filePath);
+                    ValidationConstants.getMetadataFileNotFoundString(metadataType), ValidationEntry.LEVEL.ERROR,
+                    ip.getBasePath(), filePath);
               }
             }
           }
@@ -1026,11 +1028,11 @@ public class EARKUtils {
   }
 
   protected void processMetadataFile(IPInterface ip, Logger logger, IPRepresentation representation,
-    String metadataType, MdRef mdRef, Path filePath, List<String> fileRelativeFolders) throws IPException {
+                                     String metadataType, MdRef mdRef, Path filePath, List<String> fileRelativeFolders) throws IPException {
     Optional<IPFileInterface> metadataFile = validateMetadataFile(ip, filePath, mdRef, fileRelativeFolders);
     if (metadataFile.isPresent()) {
       ValidationUtils.addInfo(ip.getValidationReport(),
-        ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(), filePath);
+          ValidationConstants.getMetadataFileFoundWithMatchingChecksumString(metadataType), ip.getBasePath(), filePath);
 
       if (IPConstants.DESCRIPTIVE.equalsIgnoreCase(metadataType)) {
         MetadataType dmdType = new MetadataType(mdRef.getMDTYPE().toUpperCase());
@@ -1046,11 +1048,11 @@ public class EARKUtils {
           // metadataVersion
           logger.debug("Setting metadata type to {}", dmdType);
           ValidationUtils.addEntry(ip.getValidationReport(), ValidationConstants.UNKNOWN_DESCRIPTIVE_METADATA_TYPE,
-            ValidationEntry.LEVEL.WARN, "Setting metadata type to " + dmdType, ip.getBasePath(), filePath);
+              ValidationEntry.LEVEL.WARN, "Setting metadata type to " + dmdType, ip.getBasePath(), filePath);
         }
 
         IPDescriptiveMetadata descriptiveMetadata = new IPDescriptiveMetadata(mdRef.getID(), metadataFile.get(),
-          dmdType, dmdVersion);
+            dmdType, dmdVersion);
         descriptiveMetadata.setCreateDate(mdRef.getCREATED());
         if (representation == null) {
           ip.addDescriptiveMetadata(descriptiveMetadata);
@@ -1090,15 +1092,15 @@ public class EARKUtils {
   }
 
   protected Optional<IPFileInterface> validateFile(IPInterface ip, Path filePath, FileType fileType,
-    List<String> fileRelativeFolders) {
+                                                   List<String> fileRelativeFolders) {
     return Utils.validateFile(ip, filePath, fileRelativeFolders, fileType.getCHECKSUM(), fileType.getCHECKSUMTYPE(),
-      fileType.getID());
+        fileType.getID());
   }
 
   protected Optional<IPFileInterface> validateMetadataFile(IPInterface ip, Path filePath, MdRef mdRef,
-    List<String> fileRelativeFolders) {
+                                                           List<String> fileRelativeFolders) {
     return Utils.validateFile(ip, filePath, fileRelativeFolders, mdRef.getCHECKSUM(), mdRef.getCHECKSUMTYPE(),
-      mdRef.getID());
+        mdRef.getID());
   }
 
   protected IPInterface processFile(IPInterface ip, DivType div, String folder, Path basePath) {
@@ -1119,28 +1121,28 @@ public class EARKUtils {
                 if (file.isPresent()) {
                   if (IPConstants.SCHEMAS.equalsIgnoreCase(folder)) {
                     ValidationUtils.addInfo(ip.getValidationReport(),
-                      ValidationConstants.SCHEMA_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(), filePath);
+                        ValidationConstants.SCHEMA_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(), filePath);
                     ip.addSchema(file.get());
                   } else if (IPConstants.DOCUMENTATION.equalsIgnoreCase(folder)) {
                     ValidationUtils.addInfo(ip.getValidationReport(),
-                      ValidationConstants.DOCUMENTATION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(), filePath);
+                        ValidationConstants.DOCUMENTATION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(), filePath);
                     ip.addDocumentation(file.get());
                   } else if (IPConstants.SUBMISSION.equalsIgnoreCase(folder) && ip instanceof AIP aip) {
                     ValidationUtils.addInfo(ip.getValidationReport(),
-                      ValidationConstants.SUBMISSION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(), filePath);
+                        ValidationConstants.SUBMISSION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(), filePath);
                     aip.addSubmission(file.get());
                   }
                 }
               } else {
                 if (IPConstants.SCHEMAS.equalsIgnoreCase(folder)) {
                   ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.SCHEMA_FILE_NOT_FOUND,
-                    ValidationEntry.LEVEL.ERROR, div, ip.getBasePath(), filePath);
+                      ValidationEntry.LEVEL.ERROR, div, ip.getBasePath(), filePath);
                 } else if (IPConstants.DOCUMENTATION.equalsIgnoreCase(folder)) {
                   ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.DOCUMENTATION_FILE_NOT_FOUND,
-                    ValidationEntry.LEVEL.ERROR, div, ip.getBasePath(), filePath);
+                      ValidationEntry.LEVEL.ERROR, div, ip.getBasePath(), filePath);
                 } else if (IPConstants.SUBMISSION.equalsIgnoreCase(folder)) {
                   ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.SUBMISSION_FILE_NOT_FOUND,
-                    ValidationEntry.LEVEL.ERROR, div, ip.getBasePath(), filePath);
+                      ValidationEntry.LEVEL.ERROR, div, ip.getBasePath(), filePath);
                 }
               }
             }
@@ -1157,7 +1159,7 @@ public class EARKUtils {
   }
 
   protected void processRepresentationFiles(IPInterface ip, MetsWrapper representationMetsWrapper,
-    IPRepresentation representation, Path representationBasePath) throws IPException {
+                                            IPRepresentation representation, Path representationBasePath) throws IPException {
 
     if (representationMetsWrapper.getDataDiv() != null && representationMetsWrapper.getDataDiv().getFptr() != null) {
       for (Fptr fptr : representationMetsWrapper.getDataDiv().getFptr()) {
@@ -1174,30 +1176,30 @@ public class EARKUtils {
                 // treat as a SIP (generic behaviour)
                 if (Files.exists(filePath)) {
                   List<String> fileRelativeFolders = Utils
-                    .getFileRelativeFolders(representationBasePath.resolve(IPConstants.DATA), filePath);
+                      .getFileRelativeFolders(representationBasePath.resolve(IPConstants.DATA), filePath);
                   Optional<IPFileInterface> file = validateFile(ip, filePath, fileType, fileRelativeFolders);
 
                   if (file.isPresent()) {
                     representation.addFile(file.get());
                     ValidationUtils.addInfo(ip.getValidationReport(),
-                      ValidationConstants.REPRESENTATION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(),
-                      filePath);
+                        ValidationConstants.REPRESENTATION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(),
+                        filePath);
                   }
                 } else {
                   // treat as a SIP shallow
                   Optional<IPFileInterface> ipFileInterface = validateFileShallow(ip, fLocat, filePath, fileType,
-                    Collections.emptyList());
+                      Collections.emptyList());
                   ipFileInterface.ifPresent(representation::addFile);
                 }
               } else {
                 // treat as a SIP shallow
                 Optional<IPFileInterface> ipFileInterface = validateFileShallow(ip, fLocat, filePath, fileType,
-                  Collections.emptyList());
+                    Collections.emptyList());
                 ipFileInterface.ifPresent(representation::addFile);
               }
             } else {
               ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.REPRESENTATION_FILE_HAS_NO_FLOCAT,
-                ValidationEntry.LEVEL.ERROR, fileType, ip.getBasePath(), representationMetsWrapper.getMetsPath());
+                  ValidationEntry.LEVEL.ERROR, fileType, ip.getBasePath(), representationMetsWrapper.getMetsPath());
             }
           }
         }
@@ -1207,21 +1209,21 @@ public class EARKUtils {
         final List<String> subDivRelativePath = new ArrayList<>();
         subDivRelativePath.add(subDiv.getLABEL());
         processRepresentationFilesSubDivs(ip, representationMetsWrapper, representation, representationBasePath, subDiv,
-          subDivRelativePath);
+            subDivRelativePath);
       }
 
       // post-process validations
       if (representation.getData().isEmpty()) {
         ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.REPRESENTATION_HAS_NO_FILES,
-          ValidationEntry.LEVEL.WARN, representationMetsWrapper.getDataDiv(), ip.getBasePath(),
-          representationMetsWrapper.getMetsPath());
+            ValidationEntry.LEVEL.WARN, representationMetsWrapper.getDataDiv(), ip.getBasePath(),
+            representationMetsWrapper.getMetsPath());
       }
     }
   }
 
   protected void processRepresentationFilesSubDivs(IPInterface ip, MetsWrapper representationMetsWrapper,
-    IPRepresentation representation, Path representationBasePath, DivType div, List<String> relativePath)
-    throws IPException {
+                                                   IPRepresentation representation, Path representationBasePath, DivType div, List<String> relativePath)
+      throws IPException {
 
     final List<Fptr> fptrs = div.getFptr();
     if (fptrs != null && !fptrs.isEmpty()) {
@@ -1239,30 +1241,30 @@ public class EARKUtils {
                 // treat as a SIP (generic behaviour)
                 if (Files.exists(filePath)) {
                   final List<String> fileRelativeFolders = Utils
-                    .getFileRelativeFolders(representationBasePath.resolve(IPConstants.DATA), filePath);
+                      .getFileRelativeFolders(representationBasePath.resolve(IPConstants.DATA), filePath);
                   final Optional<IPFileInterface> file = validateFile(ip, filePath, fileType, fileRelativeFolders);
 
                   if (file.isPresent()) {
                     representation.addFile(file.get());
                     ValidationUtils.addInfo(ip.getValidationReport(),
-                      ValidationConstants.REPRESENTATION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(),
-                      filePath);
+                        ValidationConstants.REPRESENTATION_FILE_FOUND_WITH_MATCHING_CHECKSUMS, ip.getBasePath(),
+                        filePath);
                   }
                 } else {
                   // treat as a SIP shallow
                   final Optional<IPFileInterface> ipFileInterface = validateFileShallow(ip, fLocat, filePath, fileType,
-                    relativePath);
+                      relativePath);
                   ipFileInterface.ifPresent(representation::addFile);
                 }
               } else {
                 // treat as a SIP shallow
                 final Optional<IPFileInterface> ipFileInterface = validateFileShallow(ip, fLocat, filePath, fileType,
-                  relativePath);
+                    relativePath);
                 ipFileInterface.ifPresent(representation::addFile);
               }
             } else {
               ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.REPRESENTATION_FILE_HAS_NO_FLOCAT,
-                ValidationEntry.LEVEL.ERROR, fileType, ip.getBasePath(), representationMetsWrapper.getMetsPath());
+                  ValidationEntry.LEVEL.ERROR, fileType, ip.getBasePath(), representationMetsWrapper.getMetsPath());
             }
           }
         }
@@ -1277,20 +1279,20 @@ public class EARKUtils {
       final List<String> subDivRelativePath = new ArrayList<>(relativePath);
       subDivRelativePath.add(subDiv.getLABEL());
       processRepresentationFilesSubDivs(ip, representationMetsWrapper, representation, representationBasePath, subDiv,
-        subDivRelativePath);
+          subDivRelativePath);
     }
 
   }
 
   private Optional<IPFileInterface> validateFileShallow(IPInterface ip, FLocat fLocat, Path filePath, FileType fileType,
-    List<String> relativeFolders) {
+                                                        List<String> relativeFolders) {
     Optional<IPFileInterface> file = Optional.empty();
 
     if (URI.create(fLocat.getHref()).getScheme() != null) {
       file = Optional.of(new IPFileShallow(URI.create(fLocat.getHref()), fileType, relativeFolders));
     } else {
       ValidationUtils.addIssue(ip.getValidationReport(), ValidationConstants.REPRESENTATION_SCHEME_NOT_FOUND,
-        ValidationEntry.LEVEL.ERROR, ip.getBasePath(), filePath);
+          ValidationEntry.LEVEL.ERROR, ip.getBasePath(), filePath);
     }
 
     return file;
@@ -1315,7 +1317,7 @@ public class EARKUtils {
   }
 
   protected IPInterface processSubmissionMetadata(final MetsWrapper metsWrapper, final IPInterface ip,
-    final Path basePath) {
+                                                  final Path basePath) {
     return processFile(ip, metsWrapper.getSubmissionsDiv(), IPConstants.SUBMISSION, basePath);
   }
 

--- a/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
+++ b/src/main/java/org/roda_project/commons_ip2/model/impl/eark/EARKUtils.java
@@ -41,6 +41,7 @@ import org.roda_project.commons_ip2.mets_v1_12.beans.MetsType.MetsHdr.Agent;
 import org.roda_project.commons_ip2.mets_v1_12.beans.StructMapType;
 import org.roda_project.commons_ip2.model.AIP;
 import org.roda_project.commons_ip2.model.IPConstants;
+import org.roda_project.commons_ip2.model.IPContentInformationType;
 import org.roda_project.commons_ip2.model.IPContentType;
 import org.roda_project.commons_ip2.model.IPDescriptiveMetadata;
 import org.roda_project.commons_ip2.model.IPFile;
@@ -564,6 +565,7 @@ public class EARKUtils {
         ip.setModificationDate(mainMets.getMetsHdr().getLASTMODDATE());
         ip.setStatus(IPStatus.parse(mainMets.getMetsHdr().getRECORDSTATUS()));
         setIPContentType(mainMets, ip);
+        setIPContentInformationType(mainMets, ip);
         addAgentsToMETS(mainMets, ip, null);
 
         ValidationUtils.addInfo(ip.getValidationReport(), ValidationConstants.MAIN_METS_IS_VALID, ipPath, mainMETSFile);
@@ -600,9 +602,44 @@ public class EARKUtils {
       throw new ParseException("METS 'OAISPACKAGETYPE' attribute does not contain a valid package type");
     }
 
-    String type = "".equals(mets.getOTHERCONTENTINFORMATIONTYPE()) ? mets.getCONTENTINFORMATIONTYPE()
-      : mets.getOTHERCONTENTINFORMATIONTYPE();
-    ip.setContentType(new IPContentType(type));
+    IPContentType ipContentType = getContentType(mets);
+    ip.setContentType(ipContentType);
+  }
+
+  private IPContentType getContentType(Mets mets) throws ParseException {
+    String contentType = mets.getTYPE();
+    if (StringUtils.isBlank(contentType)) {
+      throw new ParseException("METS 'TYPE' attribute does not contain any value");
+    }
+    if ("OTHER".equalsIgnoreCase(contentType)) {
+      if (StringUtils.isBlank(mets.getOTHERTYPE())) {
+        throw new ParseException("METS 'OTHERTYPE' attribute does not contain any value");
+      }
+      contentType = mets.getOTHERTYPE();
+    }
+    return new IPContentType(contentType);
+  }
+
+  protected void setIPContentInformationType(Mets mets, IPInterface ip) throws ParseException {
+    IPContentInformationType ipContentInformationType = getIpContentInformationType(mets);
+    if (ipContentInformationType == null) {
+      return;
+    }
+    ip.setContentInformationType(ipContentInformationType);
+  }
+
+  private IPContentInformationType getIpContentInformationType(Mets mets) throws ParseException {
+    String contentInformationType = mets.getCONTENTINFORMATIONTYPE();
+    if (StringUtils.isBlank(contentInformationType)) {
+      return null;
+    }
+    if ("OTHER".equalsIgnoreCase(contentInformationType)) {
+      if (StringUtils.isBlank(mets.getOTHERCONTENTINFORMATIONTYPE())) {
+        throw new ParseException("METS 'OTHERCONTENTINFORMATIONTYPE' attribute does not contain any value");
+      }
+      contentInformationType = mets.getOTHERCONTENTINFORMATIONTYPE();
+    }
+    return new IPContentInformationType(contentInformationType);
   }
 
   protected void addAgentsToMETS(Mets mets, IPInterface ip, IPRepresentation representation) {
@@ -626,6 +663,7 @@ public class EARKUtils {
       try {
         representationMets = METSUtils.instantiateMETSFromFile(representationMetsFile);
         setRepresentationContentType(representationMets, representation);
+        setRepresentationContentInformationType(representationMets, representation);
         ValidationUtils.addInfo(ip.getValidationReport(), ValidationConstants.REPRESENTATION_METS_IS_VALID,
           ip.getBasePath(), representationMetsFile);
       } catch (JAXBException | ParseException | SAXException | IOException e) {
@@ -640,18 +678,18 @@ public class EARKUtils {
     return new MetsWrapper(representationMets, representationMetsFile);
   }
 
-  // FIXME review this
+
   protected void setRepresentationContentType(Mets mets, IPRepresentation representation) throws ParseException {
-    String contentType = mets.getCONTENTINFORMATIONTYPE();
-    if (StringUtils.isBlank(contentType)) {
-      throw new ParseException("METS 'CONTENTINFORMATIONTYPE' attribute does not contain any value");
-    }
+    IPContentType ipContentType = getContentType(mets);
+    representation.setContentType(ipContentType);
+  }
 
-    if (!"".equals(mets.getOTHERCONTENTINFORMATIONTYPE())) {
-      contentType = mets.getOTHERCONTENTINFORMATIONTYPE();
+  protected void setRepresentationContentInformationType(Mets mets, IPRepresentation representation) throws ParseException {
+    IPContentInformationType ipContentInformationType = getIpContentInformationType(mets);
+    if (ipContentInformationType == null) {
+      return;
     }
-
-    representation.setContentType(new IPContentType(contentType));
+    representation.setContentInformationType(ipContentInformationType);
   }
 
   protected IPInterface processRepresentations(MetsWrapper metsWrapper, IPInterface ip, Logger logger)

--- a/src/test/java/org/roda_project/commons_ip2/model/eark/ContentTypeParsingTest.java
+++ b/src/test/java/org/roda_project/commons_ip2/model/eark/ContentTypeParsingTest.java
@@ -7,125 +7,155 @@ import org.roda_project.commons_ip2.mets_v1_12.beans.Mets;
 import org.roda_project.commons_ip2.mets_v1_12.beans.MetsType;
 import org.roda_project.commons_ip2.model.SIP;
 
+/**
+ * Tests content type parsing from METS attributes.
+ */
 public class ContentTypeParsingTest {
 
+  private static final String SIP_TYPE = "SIP";
+  private static final String SIP_VERSION = "2.1.0";
+  private static final String TYPE_TEXT = "Text";
+  private static final String TYPE_OTHER = "Other";
+  private static final String TYPE_OTHER_UPPER = "OTHER";
+  private static final String OTHER_TYPE_VALUE = "Moving images - on tangible media";
+  private static final String CONTENT_INFO_TYPE = "ERMS";
+  private static final String OTHER_CONTENT_INFO_VALUE = "Test of other CITS";
+  private static final String EXPECTED_PARSE_EXCEPTION = "Expected ParseException";
+  private static final String MIXED = "MIXED";
 
+  /**
+   * Uses METS TYPE when TYPE is not OTHER.
+   */
   @Test
   public void contentTypeUsesType() throws ParseException {
-    Mets mets = new Mets();
-    MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
-    metsHdr.setOAISPACKAGETYPE("SIP");
+    final Mets mets = new Mets();
+    final MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
+    metsHdr.setOAISPACKAGETYPE(SIP_TYPE);
     mets.setMetsHdr(metsHdr);
 
-    mets.setTYPE("Text");
-    mets.setOTHERTYPE("Moving images - on tangible media");
+    mets.setTYPE(TYPE_TEXT);
+    mets.setOTHERTYPE(OTHER_TYPE_VALUE);
 
-    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
-    SIP sip = new EARKSIP();
+    final EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator(SIP_VERSION));
+    final SIP sip = new EARKSIP();
 
     utils.setIPContentType(mets, sip);
 
-    Assert.assertEquals("Text", sip.getContentType().asString());
+    Assert.assertEquals(TYPE_TEXT, sip.getContentType().asString());
   }
 
+  /**
+   * Uses METS OTHERTYPE when TYPE is OTHER.
+   */
   @Test
   public void contentTypeUsesOtherType() throws ParseException {
-    Mets mets = new Mets();
-    MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
-    metsHdr.setOAISPACKAGETYPE("SIP");
+    final Mets mets = new Mets();
+    final MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
+    metsHdr.setOAISPACKAGETYPE(SIP_TYPE);
     mets.setMetsHdr(metsHdr);
 
-    mets.setTYPE("Other");
-    mets.setOTHERTYPE("Moving images - on tangible media");
+    mets.setTYPE(TYPE_OTHER);
+    mets.setOTHERTYPE(OTHER_TYPE_VALUE);
 
-    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
-    SIP sip = new EARKSIP();
+    final EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator(SIP_VERSION));
+    final SIP sip = new EARKSIP();
 
     utils.setIPContentType(mets, sip);
 
-    Assert.assertEquals("Moving images - on tangible media", sip.getContentType().asString());
+    Assert.assertEquals(OTHER_TYPE_VALUE, sip.getContentType().asString());
   }
 
+  /**
+   * Uses CONTENTINFORMATIONTYPE when not OTHER.
+   */
   @Test
   public void contentInfoUsesType() throws ParseException {
-    final String CONTENT_INFORMATION_TYPE = "ERMS";
+    final Mets mets = new Mets();
+    mets.setCONTENTINFORMATIONTYPE(CONTENT_INFO_TYPE);
+    mets.setOTHERCONTENTINFORMATIONTYPE(OTHER_CONTENT_INFO_VALUE);
 
-    Mets mets = new Mets();
-    mets.setCONTENTINFORMATIONTYPE(CONTENT_INFORMATION_TYPE);
-    mets.setOTHERCONTENTINFORMATIONTYPE("Test of other CITS");
-
-    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
-    SIP sip = new EARKSIP();
+    final EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator(SIP_VERSION));
+    final SIP sip = new EARKSIP();
 
     utils.setIPContentInformationType(mets, sip);
 
-    Assert.assertEquals(CONTENT_INFORMATION_TYPE, sip.getContentInformationType().asString());
+    Assert.assertEquals(CONTENT_INFO_TYPE, sip.getContentInformationType().asString());
   }
 
+  /**
+   * Uses OTHERCONTENTINFORMATIONTYPE when CONTENTINFORMATIONTYPE is OTHER.
+   */
   @Test
   public void contentInfoUsesOtherType() throws ParseException {
-    final String OTHER_CONTENT_INFORMATION_TYPE = "Test of other CITS";
+    final Mets mets = new Mets();
+    mets.setCONTENTINFORMATIONTYPE(TYPE_OTHER_UPPER);
+    mets.setOTHERCONTENTINFORMATIONTYPE(OTHER_CONTENT_INFO_VALUE);
 
-    Mets mets = new Mets();
-    mets.setCONTENTINFORMATIONTYPE("OTHER");
-    mets.setOTHERCONTENTINFORMATIONTYPE(OTHER_CONTENT_INFORMATION_TYPE);
-
-    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
-    SIP sip = new EARKSIP();
+    final EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator(SIP_VERSION));
+    final SIP sip = new EARKSIP();
 
     utils.setIPContentInformationType(mets, sip);
 
-    Assert.assertEquals(OTHER_CONTENT_INFORMATION_TYPE, sip.getContentInformationType().asString());
+    Assert.assertEquals(OTHER_CONTENT_INFO_VALUE, sip.getContentInformationType().asString());
   }
 
+  /**
+   * Requires OTHERTYPE when TYPE is OTHER.
+   */
   @Test
   public void contentTypeOtherRequiresOtherType() {
-    Mets mets = new Mets();
-    MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
-    metsHdr.setOAISPACKAGETYPE("SIP");
+    final Mets mets = new Mets();
+    final MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
+    metsHdr.setOAISPACKAGETYPE(SIP_TYPE);
     mets.setMetsHdr(metsHdr);
 
-    mets.setTYPE("Other");
+    mets.setTYPE(TYPE_OTHER);
     mets.setOTHERTYPE("");
 
-    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
-    SIP sip = new EARKSIP();
+    final EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator(SIP_VERSION));
+    final SIP sip = new EARKSIP();
 
     try {
       utils.setIPContentType(mets, sip);
-      Assert.fail("Expected ParseException");
-    } catch (ParseException e) {
+      Assert.fail(EXPECTED_PARSE_EXCEPTION);
+    } catch (final ParseException e) {
       Assert.assertTrue(e.getMessage().contains("OTHERTYPE"));
     }
   }
 
+  /**
+   * Requires OTHERCONTENTINFORMATIONTYPE when CONTENTINFORMATIONTYPE is OTHER.
+   */
   @Test
   public void contentInfoOtherRequiresOtherType() {
-    Mets mets = new Mets();
-    mets.setCONTENTINFORMATIONTYPE("OTHER");
+    final Mets mets = new Mets();
+    mets.setCONTENTINFORMATIONTYPE(TYPE_OTHER_UPPER);
     mets.setOTHERCONTENTINFORMATIONTYPE("");
 
-    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
-    SIP sip = new EARKSIP();
+    final EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator(SIP_VERSION));
+    final SIP sip = new EARKSIP();
 
     try {
       utils.setIPContentInformationType(mets, sip);
-      Assert.fail("Expected ParseException");
-    } catch (ParseException e) {
+      Assert.fail(EXPECTED_PARSE_EXCEPTION);
+    } catch (final ParseException e) {
       Assert.assertTrue(e.getMessage().contains("OTHERCONTENTINFORMATIONTYPE"));
     }
   }
 
+  /**
+   * Leaves content information type default when blank.
+   */
   @Test
   public void contentInfoBlankKeepsDefault() throws ParseException {
-    Mets mets = new Mets();
+    final Mets mets = new Mets();
     mets.setCONTENTINFORMATIONTYPE("");
 
-    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
-    SIP sip = new EARKSIP();
+    final EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator(SIP_VERSION));
+    final SIP sip = new EARKSIP();
 
     utils.setIPContentInformationType(mets, sip);
 
-    Assert.assertEquals("MIXED", sip.getContentInformationType().asString());
+    Assert.assertEquals(MIXED, sip.getContentInformationType().asString());
   }
 }

--- a/src/test/java/org/roda_project/commons_ip2/model/eark/ContentTypeParsingTest.java
+++ b/src/test/java/org/roda_project/commons_ip2/model/eark/ContentTypeParsingTest.java
@@ -9,8 +9,9 @@ import org.roda_project.commons_ip2.model.SIP;
 
 public class ContentTypeParsingTest {
 
+
   @Test
-  public void parseContentTypeUsesTypeWhenNotOther() throws ParseException {
+  public void contentTypeUsesType() throws ParseException {
     Mets mets = new Mets();
     MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
     metsHdr.setOAISPACKAGETYPE("SIP");
@@ -28,7 +29,7 @@ public class ContentTypeParsingTest {
   }
 
   @Test
-  public void parseContentTypeUsesOtherTypeWhenTypeIsOther() throws ParseException {
+  public void contentTypeUsesOtherType() throws ParseException {
     Mets mets = new Mets();
     MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
     metsHdr.setOAISPACKAGETYPE("SIP");
@@ -46,9 +47,11 @@ public class ContentTypeParsingTest {
   }
 
   @Test
-  public void parseContentInformationTypeUsesTypeWhenNotOther() throws ParseException {
+  public void contentInfoUsesType() throws ParseException {
+    final String CONTENT_INFORMATION_TYPE = "ERMS";
+
     Mets mets = new Mets();
-    mets.setCONTENTINFORMATIONTYPE("GeoData");
+    mets.setCONTENTINFORMATIONTYPE(CONTENT_INFORMATION_TYPE);
     mets.setOTHERCONTENTINFORMATIONTYPE("Test of other CITS");
 
     EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
@@ -56,25 +59,27 @@ public class ContentTypeParsingTest {
 
     utils.setIPContentInformationType(mets, sip);
 
-    Assert.assertEquals("GeoData", sip.getContentInformationType().asString());
+    Assert.assertEquals(CONTENT_INFORMATION_TYPE, sip.getContentInformationType().asString());
   }
 
   @Test
-  public void parseContentInformationTypeUsesOtherWhenTypeIsOther() throws ParseException {
+  public void contentInfoUsesOtherType() throws ParseException {
+    final String OTHER_CONTENT_INFORMATION_TYPE = "Test of other CITS";
+
     Mets mets = new Mets();
     mets.setCONTENTINFORMATIONTYPE("OTHER");
-    mets.setOTHERCONTENTINFORMATIONTYPE("Test of other CITS");
+    mets.setOTHERCONTENTINFORMATIONTYPE(OTHER_CONTENT_INFORMATION_TYPE);
 
     EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
     SIP sip = new EARKSIP();
 
     utils.setIPContentInformationType(mets, sip);
 
-    Assert.assertEquals("Test of other CITS", sip.getContentInformationType().asString());
+    Assert.assertEquals(OTHER_CONTENT_INFORMATION_TYPE, sip.getContentInformationType().asString());
   }
 
   @Test
-  public void parseContentTypeOtherWithoutOtherTypeThrows() {
+  public void contentTypeOtherRequiresOtherType() {
     Mets mets = new Mets();
     MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
     metsHdr.setOAISPACKAGETYPE("SIP");
@@ -95,7 +100,7 @@ public class ContentTypeParsingTest {
   }
 
   @Test
-  public void parseContentInformationTypeOtherWithoutOtherTypeThrows() {
+  public void contentInfoOtherRequiresOtherType() {
     Mets mets = new Mets();
     mets.setCONTENTINFORMATIONTYPE("OTHER");
     mets.setOTHERCONTENTINFORMATIONTYPE("");
@@ -112,7 +117,7 @@ public class ContentTypeParsingTest {
   }
 
   @Test
-  public void parseContentInformationTypeBlankLeavesDefault() throws ParseException {
+  public void contentInfoBlankKeepsDefault() throws ParseException {
     Mets mets = new Mets();
     mets.setCONTENTINFORMATIONTYPE("");
 

--- a/src/test/java/org/roda_project/commons_ip2/model/eark/ContentTypeParsingTest.java
+++ b/src/test/java/org/roda_project/commons_ip2/model/eark/ContentTypeParsingTest.java
@@ -12,15 +12,25 @@ import org.roda_project.commons_ip2.model.SIP;
  */
 public class ContentTypeParsingTest {
 
+  /** OAIS package type value for SIP. */
   private static final String SIP_TYPE = "SIP";
+  /** SIP version used for generator selection. */
   private static final String SIP_VERSION = "2.1.0";
+  /** Example non-OTHER content type. */
   private static final String TYPE_TEXT = "Text";
+  /** Example OTHER content type value. */
   private static final String TYPE_OTHER = "Other";
+  /** Uppercase OTHER marker used in METS attributes. */
   private static final String TYPE_OTHER_UPPER = "OTHER";
+  /** Example OTHERTYPE value. */
   private static final String OTHER_TYPE_VALUE = "Moving images - on tangible media";
+  /** Example content information type. */
   private static final String CONTENT_INFO_TYPE = "ERMS";
+  /** Example OTHERCONTENTINFORMATIONTYPE value. */
   private static final String OTHER_CONTENT_INFO_VALUE = "Test of other CITS";
+  /** Assertion message for expected ParseException. */
   private static final String EXPECTED_PARSE_EXCEPTION = "Expected ParseException";
+  /** Default content information type string. */
   private static final String MIXED = "MIXED";
 
   /**

--- a/src/test/java/org/roda_project/commons_ip2/model/eark/ContentTypeParsingTest.java
+++ b/src/test/java/org/roda_project/commons_ip2/model/eark/ContentTypeParsingTest.java
@@ -1,0 +1,126 @@
+package org.roda_project.commons_ip2.model.impl.eark;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.roda_project.commons_ip.model.ParseException;
+import org.roda_project.commons_ip2.mets_v1_12.beans.Mets;
+import org.roda_project.commons_ip2.mets_v1_12.beans.MetsType;
+import org.roda_project.commons_ip2.model.SIP;
+
+public class ContentTypeParsingTest {
+
+  @Test
+  public void parseContentTypeUsesTypeWhenNotOther() throws ParseException {
+    Mets mets = new Mets();
+    MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
+    metsHdr.setOAISPACKAGETYPE("SIP");
+    mets.setMetsHdr(metsHdr);
+
+    mets.setTYPE("Text");
+    mets.setOTHERTYPE("Moving images - on tangible media");
+
+    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
+    SIP sip = new EARKSIP();
+
+    utils.setIPContentType(mets, sip);
+
+    Assert.assertEquals("Text", sip.getContentType().asString());
+  }
+
+  @Test
+  public void parseContentTypeUsesOtherTypeWhenTypeIsOther() throws ParseException {
+    Mets mets = new Mets();
+    MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
+    metsHdr.setOAISPACKAGETYPE("SIP");
+    mets.setMetsHdr(metsHdr);
+
+    mets.setTYPE("Other");
+    mets.setOTHERTYPE("Moving images - on tangible media");
+
+    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
+    SIP sip = new EARKSIP();
+
+    utils.setIPContentType(mets, sip);
+
+    Assert.assertEquals("Moving images - on tangible media", sip.getContentType().asString());
+  }
+
+  @Test
+  public void parseContentInformationTypeUsesTypeWhenNotOther() throws ParseException {
+    Mets mets = new Mets();
+    mets.setCONTENTINFORMATIONTYPE("GeoData");
+    mets.setOTHERCONTENTINFORMATIONTYPE("Test of other CITS");
+
+    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
+    SIP sip = new EARKSIP();
+
+    utils.setIPContentInformationType(mets, sip);
+
+    Assert.assertEquals("GeoData", sip.getContentInformationType().asString());
+  }
+
+  @Test
+  public void parseContentInformationTypeUsesOtherWhenTypeIsOther() throws ParseException {
+    Mets mets = new Mets();
+    mets.setCONTENTINFORMATIONTYPE("OTHER");
+    mets.setOTHERCONTENTINFORMATIONTYPE("Test of other CITS");
+
+    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
+    SIP sip = new EARKSIP();
+
+    utils.setIPContentInformationType(mets, sip);
+
+    Assert.assertEquals("Test of other CITS", sip.getContentInformationType().asString());
+  }
+
+  @Test
+  public void parseContentTypeOtherWithoutOtherTypeThrows() {
+    Mets mets = new Mets();
+    MetsType.MetsHdr metsHdr = new MetsType.MetsHdr();
+    metsHdr.setOAISPACKAGETYPE("SIP");
+    mets.setMetsHdr(metsHdr);
+
+    mets.setTYPE("Other");
+    mets.setOTHERTYPE("");
+
+    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
+    SIP sip = new EARKSIP();
+
+    try {
+      utils.setIPContentType(mets, sip);
+      Assert.fail("Expected ParseException");
+    } catch (ParseException e) {
+      Assert.assertTrue(e.getMessage().contains("OTHERTYPE"));
+    }
+  }
+
+  @Test
+  public void parseContentInformationTypeOtherWithoutOtherTypeThrows() {
+    Mets mets = new Mets();
+    mets.setCONTENTINFORMATIONTYPE("OTHER");
+    mets.setOTHERCONTENTINFORMATIONTYPE("");
+
+    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
+    SIP sip = new EARKSIP();
+
+    try {
+      utils.setIPContentInformationType(mets, sip);
+      Assert.fail("Expected ParseException");
+    } catch (ParseException e) {
+      Assert.assertTrue(e.getMessage().contains("OTHERCONTENTINFORMATIONTYPE"));
+    }
+  }
+
+  @Test
+  public void parseContentInformationTypeBlankLeavesDefault() throws ParseException {
+    Mets mets = new Mets();
+    mets.setCONTENTINFORMATIONTYPE("");
+
+    EARKUtils utils = new EARKUtils(new METSGeneratorFactory().getGenerator("2.1.0"));
+    SIP sip = new EARKSIP();
+
+    utils.setIPContentInformationType(mets, sip);
+
+    Assert.assertEquals("MIXED", sip.getContentInformationType().asString());
+  }
+}


### PR DESCRIPTION
  ## What changed
  - `setIPContentType` now reads `mets/@TYPE` and uses `mets/@csip:OTHERTYPE` only when `TYPE=OTHER`
  - `contentInformationType` is now populated during parsing for both main and representation METS
    - uses `mets/@csip:CONTENTINFORMATIONTYPE`
    - uses `mets/@csip:OTHERCONTENTINFORMATIONTYPE` only when `CONTENTINFORMATIONTYPE=OTHER`
  - Added unit tests to cover the four reported cases plus edge cases:
    - TYPE="Text" ignores OTHERTYPE
    - TYPE="Other" uses OTHERTYPE
    - CONTENTINFORMATIONTYPE="GeoData" ignores OTHERCONTENTINFORMATIONTYPE
    - CONTENTINFORMATIONTYPE="OTHER" uses OTHERCONTENTINFORMATIONTYPE
    - error when OTHER is set but corresponding other field is empty
    - blank CONTENTINFORMATIONTYPE leaves default

  ## Why
  Parsing currently:
  - reads `contentType` from content-information attributes (wrong source)
  - never sets `contentInformationType` at all
  This causes parsed SIPs to return incorrect defaults even when METS is correct (#372).

  ## Related
  Closes #372